### PR TITLE
(Chore) fromTheme utility functions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,12 +4,7 @@ module.exports = {
     '!packages/**/*.test.{js,jsx,ts,tsx}',
   ],
   coverageDirectory: '<rootDir>/coverage',
-  moduleFileExtensions: [
-    'ts',
-    'tsx',
-    'js',
-    'jsx',
-  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   moduleDirectories: ['node_modules', 'packages'],
   moduleNameMapper: {
     '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':

--- a/packages/asc-core/src/utils/README.md
+++ b/packages/asc-core/src/utils/README.md
@@ -1,0 +1,49 @@
+Styles utility functions
+
+### getThemeColor
+...
+
+### fillSVG
+...
+
+### fromProps
+Gets value from the props object. Useful for styled-components
+
+```js static
+import styled from 'styled-components'
+import { fromProps } from './utils/fromTheme'
+
+const Div = styled.div`
+  display: ${fromProps('display')};
+`
+
+<Div display="flex" /> // styles: { display: 'flex' }
+```
+
+### fromTheme
+Same as `fromProps`, but it will get a value from the (global) theme object. Useful for styled-components
+
+```js static
+import styled from 'styled-components'
+import fromTheme from './utils'
+
+const theme = {
+  colour: {
+    brand: '#f00'
+  },
+  fontSizes: {
+    title: 2
+  },
+  spacing: {
+    max: 4
+  }
+}
+
+const Div = styled.div`
+  background-color: ${fromTheme('colour.white')};
+  font-size: ${fromTheme('fontSizes.title')}em;
+  padding: ${fromTheme('spacing.max', spacing => spacing * 2)}rem;
+`
+
+<Div theme={theme} /> // styles: { backgroundColor: '#f00', fontSize: '2em', padding: '8rem' }
+```

--- a/packages/asc-core/src/utils/__tests__/fromTheme.test.ts
+++ b/packages/asc-core/src/utils/__tests__/fromTheme.test.ts
@@ -1,0 +1,52 @@
+import fromTheme, { fromProps, valueFromObject } from '../fromTheme'
+
+describe('valueFromObject', () => {
+  it('should return undefined when an unnested key is not found', () => {
+    const notFound = valueFromObject('foo', {})
+    expect(notFound).toBeUndefined()
+  })
+
+  it('should throw when a nested key cannot be found', () => {
+    expect(() => valueFromObject('foo.bar', {})).toThrow()
+  })
+})
+
+describe('fromProps', () => {
+  it('should return a value from props object', () => {
+    expect(fromProps('foo')({ foo: 'bar' })).toBe('bar')
+    expect(fromProps('foo')({ foo: 'bar' })).not.toBe('baz')
+    expect(fromProps('foo.bar.baz')({ foo: { bar: { baz: 'qux' } } })).toBe(
+      'qux',
+    )
+    expect(fromProps('value', (value: number) => value * 2)({ value: 1 })).toBe(
+      2,
+    )
+    expect(fromProps('foo')()).toBeUndefined()
+  })
+
+  it('should not throw when a nested key cannot be found', () => {
+    expect(() => fromProps('foo')).not.toThrow()
+    expect(() => fromProps('foo')()).not.toThrow()
+    expect(() => fromProps('foo.bar')()).not.toThrow()
+  })
+})
+
+describe('fromTheme', () => {
+  const theme = {
+    colours: { white: '#fff' },
+    units: 'px',
+    size: 1,
+  }
+
+  it('should return a value from the theme object', () => {
+    expect(fromTheme('colours.white')({ theme })).toBe(theme.colours.white)
+    expect(fromTheme('units')({ theme })).toBe(theme.units)
+    expect(fromTheme('size', (value: number) => value * 2)({ theme })).toBe(
+      theme.size * 2,
+    )
+  })
+
+  it('should not throw when a nested key cannot be found', () => {
+    expect(() => fromTheme('colours.white.light')({ theme })).not.toThrow()
+  })
+})

--- a/packages/asc-core/src/utils/fromTheme.ts
+++ b/packages/asc-core/src/utils/fromTheme.ts
@@ -1,0 +1,35 @@
+/**
+ * Returns a (deeply) nested value from an object
+ * @example To retrieve the value for 'baz' from const obj = { foo: { bar: { baz: 'qux' }}}, call the function like so:
+ * const bazValue = valueFromObject('foo.bar.baz', obj);
+ * @throws {Error} whenever the requested key cannot be found
+ */
+const valueFromObject = (key: string, obj: object): any =>
+  key.split('.').reduce((reduced, index) => reduced[index], obj)
+
+/**
+ * A higher-order function that gets a value from the given object. Designed to work with `styled-components`
+ */
+const fromProps = (identifier: string, callback?: Function): any => (
+  source: object = {},
+) => {
+  try {
+    const value = valueFromObject(identifier, source)
+    return callback ? callback(value) : value
+  } catch (e) {
+    // will throw an error when a nested property doesn't exist
+    // for instance branding.colours.primary.light where 'light' is not present
+    return undefined
+  }
+}
+
+/**
+ * A shortcut to the `fromProps` that will get a value out of the props.theme object
+ */
+const fromTheme = (identifier: string, callback?: Function): any => ({
+  theme,
+}: {
+  theme: object
+}) => fromProps(identifier, callback)(theme)
+
+export { fromTheme as default, fromProps, valueFromObject }

--- a/packages/asc-core/src/utils/index.ts
+++ b/packages/asc-core/src/utils/index.ts
@@ -1,0 +1,3 @@
+export { default as fromTheme } from './fromTheme'
+export { default as getThemeColor } from './getThemeColor'
+export { default as fillSVG } from './fillSVG'


### PR DESCRIPTION
This PR:
- adds a utility function for theme configuration value retrieval (`fromTheme`) that can be used inside a styled component,
- adds an index file for the `asc-core/src/utils` folder