### PR TITLE
Theme selectors improvements

### DIFF
--- a/packages/asc-core/src/components/ButtonBaseStyle/ButtonBaseStyle.ts
+++ b/packages/asc-core/src/components/ButtonBaseStyle/ButtonBaseStyle.ts
@@ -1,7 +1,7 @@
 import { transitions } from 'polished'
 import { Theme } from '../../theme'
 import styled from '../../styled-components'
-import { getColorFromTheme, focusStyle } from '../../utils'
+import { color as themeColor, focusStyle } from '../../utils'
 import { flexboxMinHeightFix } from '../shared/ie-fixes'
 
 export type Props = {
@@ -24,13 +24,13 @@ const ButtonBaseStyle = styled.button<Props>`
   ${focusStyle()}
   ${transitions(['color', 'background-color'], '0.1s ease-in-out')};
 
-  background: ${({ color, theme }) => getColorFromTheme(theme, color)};
+  background: ${({ color, theme }) => themeColor(color)({ theme })};
 
   &:hover {
     background: ${({ color, theme }) =>
       color
-        ? getColorFromTheme(theme, color, 'dark')
-        : getColorFromTheme(theme, 'tint', 'level3')};
+        ? themeColor(color, 'dark')({ theme })
+        : themeColor('tint', 'level3')({ theme })};
   }
 
   ${flexboxMinHeightFix()}

--- a/packages/asc-core/src/components/ButtonBaseStyle/ButtonBaseStyle.ts
+++ b/packages/asc-core/src/components/ButtonBaseStyle/ButtonBaseStyle.ts
@@ -1,7 +1,7 @@
 import { transitions } from 'polished'
 import { Theme } from '../../theme'
 import styled from '../../styled-components'
-import { getColorFromTheme, getFocusStyle } from '../../utils'
+import { getColorFromTheme, focusStyle } from '../../utils'
 import { flexboxMinHeightFix } from '../shared/ie-fixes'
 
 export type Props = {
@@ -21,7 +21,7 @@ const ButtonBaseStyle = styled.button<Props>`
   font-size: 16px;
   font-weight: normal;
   padding: 0 10px 0 10px;
-  ${({ theme }) => getFocusStyle(theme)}
+  ${focusStyle()}
   ${transitions(['color', 'background-color'], '0.1s ease-in-out')};
 
   background: ${({ color, theme }) => getColorFromTheme(theme, color)};

--- a/packages/asc-core/src/components/ButtonStyle/ButtonStyle.ts
+++ b/packages/asc-core/src/components/ButtonStyle/ButtonStyle.ts
@@ -1,6 +1,6 @@
 import { readableColor } from 'polished'
 import styled from '../../styled-components'
-import { fillSvgFromTheme, getColorFromTheme } from '../../utils'
+import { svgFill, getColorFromTheme } from '../../utils'
 import ButtonBaseStyle, { ButtonBaseStyleProps } from '../ButtonBaseStyle'
 
 export type Props = ButtonBaseStyleProps
@@ -25,7 +25,7 @@ const ButtonStyle = styled(ButtonBaseStyle)<Props>`
   & svg {
     width: 30px;
     height: 30px;
-    ${({ color, theme }) => fillSvgFromTheme(theme, color)};
+    ${({ color, theme }) => svgFill(color)({ theme })};
   }
 `
 

--- a/packages/asc-core/src/components/ContextMenu/ContextMenuButton.ts
+++ b/packages/asc-core/src/components/ContextMenu/ContextMenuButton.ts
@@ -1,8 +1,8 @@
 import styled from '../../styled-components'
-import { getColorFromTheme, getFocusStyle } from '../../utils'
+import { getColorFromTheme, focusStyle } from '../../utils'
 
 const ContextMenuButton = styled.button`
-  ${({ theme }) => getFocusStyle(theme)}
+  ${focusStyle()}
   display: flex;
   background-color: ${({ theme }) =>
     getColorFromTheme(theme, 'tint', 'level1')};

--- a/packages/asc-core/src/components/ContextMenu/ContextMenuButton.ts
+++ b/packages/asc-core/src/components/ContextMenu/ContextMenuButton.ts
@@ -1,11 +1,10 @@
 import styled from '../../styled-components'
-import { getColorFromTheme, focusStyle } from '../../utils'
+import { color, focusStyle } from '../../utils'
 
 const ContextMenuButton = styled.button`
   ${focusStyle()}
   display: flex;
-  background-color: ${({ theme }) =>
-    getColorFromTheme(theme, 'tint', 'level1')};
+  background-color: ${color('tint', 'level1')};
   align-items: center;
   height: 32px;
   padding: 0 6px;

--- a/packages/asc-core/src/components/ContextMenu/ContextMenuItem.ts
+++ b/packages/asc-core/src/components/ContextMenu/ContextMenuItem.ts
@@ -1,6 +1,6 @@
 import styled from '../../styled-components'
 import { ContextMenu } from './types'
-import { getColorFromTheme, fromTheme } from '../../utils'
+import { color, getColorFromTheme, fromTheme } from '../../utils'
 
 export const ContextMenuItem = styled.li<ContextMenu.ContextMenuItemProps>`
   padding: 0;
@@ -24,8 +24,7 @@ export const ContextMenuItem = styled.li<ContextMenu.ContextMenuItemProps>`
   &:hover,
   &:focus {
     outline: none;
-    background-color: ${({ theme }) =>
-      getColorFromTheme(theme, 'tint', 'level2')}};
+    background-color: ${color('tint', 'level2')}};
   }
 `
 

--- a/packages/asc-core/src/components/ContextMenu/ContextMenuItem.ts
+++ b/packages/asc-core/src/components/ContextMenu/ContextMenuItem.ts
@@ -1,6 +1,6 @@
 import styled from '../../styled-components'
 import { ContextMenu } from './types'
-import { getColorFromTheme, getTypographyFromTheme } from '../../utils'
+import { getColorFromTheme, fromTheme } from '../../utils'
 
 export const ContextMenuItem = styled.li<ContextMenu.ContextMenuItemProps>`
   padding: 0;
@@ -11,7 +11,7 @@ export const ContextMenuItem = styled.li<ContextMenu.ContextMenuItemProps>`
   height: 34px;
   width: 100%;
   cursor: pointer;
-  font-size: ${({ theme }) => getTypographyFromTheme(theme, 'fontSize')};
+  font-size: ${fromTheme(`typography.fontSize')};
 
   & > span:first-child {
     margin: 5px 6px;

--- a/packages/asc-core/src/components/ContextMenu/ContextMenuItem.ts
+++ b/packages/asc-core/src/components/ContextMenu/ContextMenuItem.ts
@@ -11,7 +11,7 @@ export const ContextMenuItem = styled.li<ContextMenu.ContextMenuItemProps>`
   height: 34px;
   width: 100%;
   cursor: pointer;
-  font-size: ${fromTheme(`typography.fontSize')};
+  font-size: ${fromTheme('typography.fontSize')};
 
   & > span:first-child {
     margin: 5px 6px;

--- a/packages/asc-core/src/components/ContextMenu/ContextMenuList.ts
+++ b/packages/asc-core/src/components/ContextMenu/ContextMenuList.ts
@@ -1,6 +1,6 @@
 import styled from '../../styled-components'
 import { ContextMenu } from './types'
-import { getColorFromTheme } from '../../utils'
+import { color } from '../../utils'
 
 const ContextMenuList = styled.ul<ContextMenu.ContextMenuListProps>`
   display: flex;
@@ -19,9 +19,8 @@ export const ContextMenuListWrapper = styled.div.attrs(() => ({
   tabIndex: -1,
 }))<ContextMenu.ContextMenuListProps>`
   order: ${({ position }) => (position === 'bottom' ? -1 : 0)};
-  background-color: ${({ theme }) =>
-    getColorFromTheme(theme, 'tint', 'level1')};
-  border: 1px solid ${({ theme }) => getColorFromTheme(theme, 'tint', 'level7')};
+  background-color: ${color('tint', 'level1')};
+  border: 1px solid ${color('tint', 'level7')};
   max-width: 250px;
   width: 100%;
   &:focus {

--- a/packages/asc-core/src/components/GlobalStyle/GlobalStyle.ts
+++ b/packages/asc-core/src/components/GlobalStyle/GlobalStyle.ts
@@ -7,7 +7,7 @@ export default createGlobalStyle`
   ${({ theme }) => fromTheme('globalStyle')({ theme })}
 
   body {
-    font-family: ${fromTheme(`typography.fontFamily')};
+    font-family: ${fromTheme('typography.fontFamily')};
   }
 
   [aria-hidden="true"] {

--- a/packages/asc-core/src/components/GlobalStyle/GlobalStyle.ts
+++ b/packages/asc-core/src/components/GlobalStyle/GlobalStyle.ts
@@ -1,13 +1,13 @@
 import { normalize } from 'polished'
 import { createGlobalStyle } from '../../styled-components'
-import { fromTheme, getTypographyFromTheme } from '../../utils'
+import { fromTheme } from '../../utils'
 
 export default createGlobalStyle`
   ${normalize()}
   ${({ theme }) => fromTheme('globalStyle')({ theme })}
 
   body {
-    font-family: ${({ theme }) => getTypographyFromTheme(theme, 'fontFamily')};
+    font-family: ${fromTheme(`typography.fontFamily')};
   }
 
   [aria-hidden="true"] {

--- a/packages/asc-core/src/components/HeaderStyle/HeaderMenuStyle.ts
+++ b/packages/asc-core/src/components/HeaderStyle/HeaderMenuStyle.ts
@@ -1,9 +1,8 @@
 import styled from '../../styled-components'
-import { getBreakpointFromTheme } from '../../utils'
+import { breakpoint } from '../../utils'
 
 const HeaderMenuStyle = styled.div`
-  @media screen and ${({ theme }) =>
-      getBreakpointFromTheme(theme, 'max-width', 'laptop')} {
+  @media screen and ${breakpoint('max-width', 'laptop')} {
     width: 50px;
   }
 `

--- a/packages/asc-core/src/components/HeaderStyle/HeaderSearchStyle.ts
+++ b/packages/asc-core/src/components/HeaderStyle/HeaderSearchStyle.ts
@@ -1,16 +1,14 @@
 import styled from '../../styled-components'
-import { getBreakpointFromTheme } from '../../utils'
+import { breakpoint } from '../../utils'
 
 const HeaderSearchStyle = styled.div`
   overflow: hidden;
 
-  @media screen and ${({ theme }) =>
-      getBreakpointFromTheme(theme, 'max-width', 'tablet')} {
+  @media screen and ${breakpoint('max-width', 'tablet')} {
     width: 50px;
   }
 
-  @media screen and ${({ theme }) =>
-      getBreakpointFromTheme(theme, 'min-width', 'tablet')} {
+  @media screen and ${breakpoint('min-width', 'tablet')} {
     flex-grow: 1;
   }
 `

--- a/packages/asc-core/src/components/HeaderStyle/HeaderStyle.ts
+++ b/packages/asc-core/src/components/HeaderStyle/HeaderStyle.ts
@@ -1,5 +1,5 @@
 import styled from '../../styled-components'
-import { getColorFromTheme } from '../../utils'
+import { color } from '../../utils'
 
 export type Props = {}
 
@@ -9,8 +9,7 @@ const HeaderStyle = styled.div<Props>`
   width: 100%;
   flex-flow: no-wrap;
   box-shadow: 0 0 4px 0px rgba(0, 0, 0, 0.4);
-  background-color: ${({ theme }) =>
-    getColorFromTheme(theme, 'tint', 'level1')};
+  background-color: ${color('tint', 'level1')};
   position: fixed;
   top: 0;
 `

--- a/packages/asc-core/src/components/HeaderStyle/HeaderTitleStyle.ts
+++ b/packages/asc-core/src/components/HeaderStyle/HeaderTitleStyle.ts
@@ -1,9 +1,8 @@
 import styled from '../../styled-components'
-import { getBreakpointFromTheme } from '../../utils'
+import { breakpoint } from '../../utils'
 
 const HeaderTitleStyle = styled.div<{}>`
-  @media screen and ${({ theme }) =>
-      getBreakpointFromTheme(theme, 'max-width', 'tablet')} {
+  @media screen and ${breakpoint('max-width', 'tablet')} {
     flex-grow: 1;
   }
 
@@ -23,14 +22,12 @@ const HeaderTitleStyle = styled.div<{}>`
     color: #000;
     text-decoration: none;
 
-    @media screen and ${({ theme }) =>
-        getBreakpointFromTheme(theme, 'max-width', 'mobileM')} {
+    @media screen and ${breakpoint('max-width', 'mobileM')} {
       line-height: 18px;
       font-size: 14px;
     }
 
-    @media screen and ${({ theme }) =>
-        getBreakpointFromTheme(theme, 'min-width', 'mobileM')} {
+    @media screen and ${breakpoint('min-width', 'mobileM')} {
       line-height: 20px;
       font-size: 16px;
     }

--- a/packages/asc-core/src/components/IconStyle/IconStyle.ts
+++ b/packages/asc-core/src/components/IconStyle/IconStyle.ts
@@ -1,6 +1,6 @@
 import { Theme } from '../../theme'
 import styled from '../../styled-components'
-import { fillSvgFromTheme } from '../../utils'
+import { svgFill } from '../../utils'
 
 export type Props = {
   inline?: boolean
@@ -31,7 +31,7 @@ const IconStyle = styled.span<Props>`
   & > svg {
     width: inherit;
     height: inherit;
-    ${({ color, theme }) => fillSvgFromTheme(theme, color)};
+    ${({ color, theme }) => svgFill(color)({ theme })};
 `
 
 export default IconStyle

--- a/packages/asc-core/src/components/ShareButtonStyle/ShareButtonStyle.ts
+++ b/packages/asc-core/src/components/ShareButtonStyle/ShareButtonStyle.ts
@@ -1,6 +1,6 @@
 import styled from '../../styled-components'
 import IconButtonStyle, { IconButtonStyleProps } from '../IconButtonStyle'
-import { getColorFromTheme } from '../../utils'
+import { color, getColorFromTheme } from '../../utils'
 
 export type Props = IconButtonStyleProps
 
@@ -8,7 +8,7 @@ const ShareButtonStyle = styled(IconButtonStyle)<Props>`
   padding: 0px;
   position: relative;
   justify-content: center;
-  background: ${({ theme }) => getColorFromTheme(theme, 'tint', 'level5')}};
+  background: ${color('tint', 'level5')}};
 
   &:focus,
   &:hover {

--- a/packages/asc-core/src/components/Typography/Typography.ts
+++ b/packages/asc-core/src/components/Typography/Typography.ts
@@ -67,22 +67,11 @@ export default (element: Variant): StyledComponent<any, any> => styled(
     css`
       margin-bottom: ${em('15px')};
     `}
-  ${({ theme }) => {
-    const {
-      fontWeight,
-      fontSize,
-      fontFamily,
-      letterSpacing,
-      lineHeight,
-    } = fromTheme(element)({ theme })
-    return css`
-      font-family: ${fontFamily};
-      font-weight: ${fontWeight};
-      font-size: ${fontSize};
-      letter-spacing: ${letterSpacing};
-      line-height: ${lineHeight};
-    `
-  }}
+  font-family: ${fromTheme('typography.fontFamily')};
+  font-weight: ${fromTheme('typography.fontWeight')};
+  font-size: ${fromTheme('typography.fontSize')};
+  letter-spacing: ${fromTheme('typography.letterSpacing')};
+  line-height: ${fromTheme('typography.lineHeight')};
   font-style: normal;
   font-stretch: normal;
   letter-spacing: normal;

--- a/packages/asc-core/src/components/Typography/Typography.ts
+++ b/packages/asc-core/src/components/Typography/Typography.ts
@@ -1,7 +1,7 @@
 import { StyledComponent } from 'styled-components'
 import { em, margin } from 'polished'
 import styled, { css } from '../../styled-components'
-import { getColorFromTheme, focusStyle, fromTheme } from '../../utils'
+import { color, focusStyle, getTypographyFromTheme } from '../../utils'
 
 export type Props = {
   gutterBottom?: boolean
@@ -15,7 +15,7 @@ const headings = css`
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  color: ${({ theme }) => getColorFromTheme(theme, 'tint', 'level7')};
+  color: ${color('tint', 'level7')};
 `
 
 const extendedStyles = {
@@ -35,13 +35,13 @@ const extendedStyles = {
     line-height: 1.25;
   `,
   a: css`
-    color: ${({ theme }) => getColorFromTheme(theme, 'primary')}
+    color: ${color('primary')};
     display: inline-block;
 
     ${focusStyle()}
 
     &:hover {
-      color: ${({ theme }) => getColorFromTheme(theme, 'secondary')}
+      color: ${color('secondary')};
     }
   `,
 }
@@ -67,12 +67,23 @@ export default (element: Variant): StyledComponent<any, any> => styled(
     css`
       margin-bottom: ${em('15px')};
     `}
-  font-family: ${fromTheme('typography.fontFamily')};
-  font-weight: ${fromTheme('typography.fontWeight')};
-  font-size: ${fromTheme('typography.fontSize')};
-  letter-spacing: ${fromTheme('typography.letterSpacing')};
-  line-height: ${fromTheme('typography.lineHeight')};
-  font-style: normal;
+    ${({ theme }) => {
+      const {
+        fontWeight,
+        fontSize,
+        fontFamily,
+        letterSpacing,
+        lineHeight,
+      } = getTypographyFromTheme(theme, element)
+      return css`
+        font-family: ${fontFamily};
+        font-weight: ${fontWeight};
+        font-size: ${fontSize};
+        letter-spacing: ${letterSpacing};
+        line-height: ${lineHeight};
+      `
+    }}
+    font-style: normal;
   font-stretch: normal;
   letter-spacing: normal;
 `

--- a/packages/asc-core/src/components/Typography/Typography.ts
+++ b/packages/asc-core/src/components/Typography/Typography.ts
@@ -1,11 +1,7 @@
 import { StyledComponent } from 'styled-components'
 import { em, margin } from 'polished'
 import styled, { css } from '../../styled-components'
-import {
-  getColorFromTheme,
-  getTypographyFromTheme,
-  getFocusStyle,
-} from '../../utils'
+import { getColorFromTheme, getFocusStyle, fromTheme } from '../../utils'
 
 export type Props = {
   gutterBottom?: boolean
@@ -78,7 +74,7 @@ export default (element: Variant): StyledComponent<any, any> => styled(
       fontFamily,
       letterSpacing,
       lineHeight,
-    } = getTypographyFromTheme(theme, element)
+    } = fromTheme(element)({ theme })
     return css`
       font-family: ${fontFamily};
       font-weight: ${fontWeight};

--- a/packages/asc-core/src/components/Typography/Typography.ts
+++ b/packages/asc-core/src/components/Typography/Typography.ts
@@ -1,7 +1,7 @@
 import { StyledComponent } from 'styled-components'
 import { em, margin } from 'polished'
 import styled, { css } from '../../styled-components'
-import { getColorFromTheme, getFocusStyle, fromTheme } from '../../utils'
+import { getColorFromTheme, focusStyle, fromTheme } from '../../utils'
 
 export type Props = {
   gutterBottom?: boolean
@@ -38,7 +38,7 @@ const extendedStyles = {
     color: ${({ theme }) => getColorFromTheme(theme, 'primary')}
     display: inline-block;
 
-    ${({ theme }) => getFocusStyle(theme)}
+    ${focusStyle()}
 
     &:hover {
       color: ${({ theme }) => getColorFromTheme(theme, 'secondary')}

--- a/packages/asc-core/src/utils/README.md
+++ b/packages/asc-core/src/utils/README.md
@@ -70,27 +70,6 @@ const ButtonStyle = styled.button`
 <ButtonStyle theme={theme} /> // styles: { backgroundColor: '#000', color: '#fff' }
 ```
 
-## getTypographyFromTheme
-
-Extends `fromTheme`, but it's specified to the theme typography.
-
-```js static
-import styled from 'styled-components'
-import { getTypographyFromTheme } from './utils'
-
-const theme = {
-  typography: {
-    fontSize: '16px'
-  }
-}
-
-const TitleStyle = styled.h1`
-  font-size: ${theme => getTypographyFromTheme(theme, 'fontSize')};
-`
-
-<TitleStyle theme={theme} /> // styles: { font-size: '16px' }
-```
-
 ## fillSvgFromTheme
 
 ...

--- a/packages/asc-core/src/utils/README.md
+++ b/packages/asc-core/src/utils/README.md
@@ -70,6 +70,6 @@ const ButtonStyle = styled.button`
 <ButtonStyle theme={theme} /> // styles: { backgroundColor: '#000', color: '#fff' }
 ```
 
-## fillSvgFromTheme
+## svgFill
 
 ...

--- a/packages/asc-core/src/utils/__tests__/themeUtils.test.ts
+++ b/packages/asc-core/src/utils/__tests__/themeUtils.test.ts
@@ -1,9 +1,4 @@
-import {
-  getColorFromTheme,
-  getFocusStyle,
-  getBreakpointFromTheme,
-  fillSvgFromTheme,
-} from '../themeUtils'
+import { color, focusStyle, breakpoint, svgFill } from '../themeUtils'
 import breakpoints from '../../theme/default/breakpoints'
 import colors from '../../theme/default/colors'
 import globalStyle from '../../theme/default/globalStyle'
@@ -24,17 +19,17 @@ describe('getColorFromTheme', () => {
   }
 
   it('should return the requested color from theme', () => {
-    expect(getColorFromTheme(theme, 'primary', 'main')).toBe('#fff')
-    expect(getColorFromTheme(theme, 'primary', 'dark')).toBe('#000')
-    expect(getColorFromTheme(theme, 'primary')).toBe('#fff')
+    expect(color('primary', 'main')({ theme })).toBe('#fff')
+    expect(color('primary', 'dark')({ theme })).toBe('#000')
+    expect(color('primary')({ theme })).toBe('#fff')
   })
 
   it('should returen the default color when the colorType is not provided', () => {
-    expect(getColorFromTheme(theme)).toBe('#ffffff')
+    expect(color()({ theme })).toBe('#ffffff')
   })
 })
 
-describe('getFocusStyle', () => {
+describe('focusStyle', () => {
   const theme = {
     breakpoints,
     globalStyle,
@@ -49,7 +44,7 @@ describe('getFocusStyle', () => {
   }
 
   it('should return the focusstyle from theme', () => {
-    const result = getFocusStyle(theme)
+    const result = focusStyle()({ theme })
     expect(result).toContain('#abcde')
   })
 })
@@ -63,22 +58,20 @@ describe('getBreakpontFromTheme', () => {
   }
 
   it("should return undefined when the breakpoint doesn't exist", () => {
-    expect(
-      getBreakpointFromTheme(theme, 'max-width', 'not-valid'),
-    ).toBeUndefined()
+    expect(breakpoint('max-width', 'not-valid')({ theme })).toBeUndefined()
   })
 
   it('should return the right breakpoint', () => {
-    expect(getBreakpointFromTheme(theme, 'max-width', 'desktop')).toEqual(
+    expect(breakpoint('max-width', 'desktop')({ theme })).toEqual(
       '(max-width: 2560px)',
     )
-    expect(getBreakpointFromTheme(theme, 'min-width', 'mobileL')).toEqual(
+    expect(breakpoint('min-width', 'mobileL')({ theme })).toEqual(
       '(min-width: 425px)',
     )
   })
 })
 
-describe('fillSvgFromTheme', () => {
+describe('svgFill', () => {
   const theme = {
     breakpoints,
     globalStyle,
@@ -87,10 +80,10 @@ describe('fillSvgFromTheme', () => {
   }
 
   it("should return een empty string when the color doesn't exist", () => {
-    expect(fillSvgFromTheme(theme)).toBe('')
+    expect(svgFill()({ theme })).toBe('')
   })
 
   it('should return the right fill color for the svg', () => {
-    expect(fillSvgFromTheme(theme, 'tint', 'level5')).toContain('fill: #000')
+    expect(svgFill('tint', 'level5')({ theme })).toContain('fill: #000')
   })
 })

--- a/packages/asc-core/src/utils/__tests__/themeUtils.test.ts
+++ b/packages/asc-core/src/utils/__tests__/themeUtils.test.ts
@@ -1,6 +1,5 @@
 import {
   getColorFromTheme,
-  getTypographyFromTheme,
   getFocusStyle,
   getBreakpointFromTheme,
   fillSvgFromTheme,
@@ -32,22 +31,6 @@ describe('getColorFromTheme', () => {
 
   it('should returen the default color when the colorType is not provided', () => {
     expect(getColorFromTheme(theme)).toBe('#ffffff')
-  })
-})
-
-describe('getTypographyFromTheme', () => {
-  it('should return the requested typography from theme', () => {
-    const theme = {
-      breakpoints,
-      globalStyle,
-      colors,
-      typography: {
-        ...typography,
-        fontSize: '16px',
-      },
-    }
-
-    expect(getTypographyFromTheme(theme, 'fontSize')).toBe('16px')
   })
 })
 

--- a/packages/asc-core/src/utils/__tests__/themeUtils.test.ts
+++ b/packages/asc-core/src/utils/__tests__/themeUtils.test.ts
@@ -1,4 +1,10 @@
-import { color, focusStyle, breakpoint, svgFill } from '../themeUtils'
+import {
+  color,
+  focusStyle,
+  breakpoint,
+  svgFill,
+  getTypographyFromTheme,
+} from '../themeUtils'
 import breakpoints from '../../theme/default/breakpoints'
 import colors from '../../theme/default/colors'
 import globalStyle from '../../theme/default/globalStyle'
@@ -29,6 +35,22 @@ describe('getColorFromTheme', () => {
   })
 })
 
+describe('getTypographyFromTheme', () => {
+  it('should return the requested typography from theme', () => {
+    const theme = {
+      breakpoints,
+      globalStyle,
+      colors,
+      typography: {
+        ...typography,
+        fontSize: '16px',
+      },
+    }
+
+    expect(getTypographyFromTheme(theme, 'fontSize')).toBe('16px')
+  })
+})
+
 describe('focusStyle', () => {
   const theme = {
     breakpoints,
@@ -49,7 +71,7 @@ describe('focusStyle', () => {
   })
 })
 
-describe('getBreakpontFromTheme', () => {
+describe('breakpoint', () => {
   const theme = {
     breakpoints,
     globalStyle,

--- a/packages/asc-core/src/utils/index.ts
+++ b/packages/asc-core/src/utils/index.ts
@@ -2,7 +2,6 @@ export { default as fromTheme } from './fromTheme'
 export {
   getColorFromTheme,
   focusStyle,
-  getBreakpointFromTheme,
   breakpoint,
   svgFill,
 } from './themeUtils'

--- a/packages/asc-core/src/utils/index.ts
+++ b/packages/asc-core/src/utils/index.ts
@@ -1,6 +1,8 @@
 export { default as fromTheme } from './fromTheme'
 export {
+  color,
   getColorFromTheme,
+  getTypographyFromTheme,
   focusStyle,
   breakpoint,
   svgFill,

--- a/packages/asc-core/src/utils/index.ts
+++ b/packages/asc-core/src/utils/index.ts
@@ -1,7 +1,6 @@
 export { default as fromTheme } from './fromTheme'
 export {
   getColorFromTheme,
-  getTypographyFromTheme,
   getFocusStyle,
   getBreakpointFromTheme,
   fillSvgFromTheme,

--- a/packages/asc-core/src/utils/index.ts
+++ b/packages/asc-core/src/utils/index.ts
@@ -1,7 +1,8 @@
 export { default as fromTheme } from './fromTheme'
 export {
   getColorFromTheme,
-  getFocusStyle,
+  focusStyle,
   getBreakpointFromTheme,
-  fillSvgFromTheme,
+  breakpoint,
+  svgFill,
 } from './themeUtils'

--- a/packages/asc-core/src/utils/themeUtils.ts
+++ b/packages/asc-core/src/utils/themeUtils.ts
@@ -38,25 +38,12 @@ export const breakpoint = (type: Theme.TypeBreakpoint, variant: string) => ({
 }: {
   theme: Theme.ThemeInterface
 }) => {
-  const breakpoint: Theme.GetBreakpointFunc = fromTheme(
+  const breakpointFunc: Theme.GetBreakpointFunc = fromTheme(
     `breakpoints.${[variant]}`,
   )({
     theme,
   })
-  return breakpoint && breakpoint(type)
-}
-
-export const getBreakpointFromTheme = (
-  theme: Theme.ThemeInterface,
-  type: Theme.TypeBreakpoint,
-  variant: string,
-) => {
-  const breakpoint: Theme.GetBreakpointFunc = fromTheme(
-    `breakpoints.${[variant]}`,
-  )({
-    theme,
-  })
-  return breakpoint && breakpoint(type)
+  return breakpointFunc && breakpointFunc(type)
 }
 
 export const svgFill = (

--- a/packages/asc-core/src/utils/themeUtils.ts
+++ b/packages/asc-core/src/utils/themeUtils.ts
@@ -22,6 +22,13 @@ export const getColorFromTheme = (
     : fromTheme('colors.tint.level1')({ theme })
 }
 
+export const getTypographyFromTheme = (
+  theme: Theme.ThemeInterface,
+  attributeType: string,
+) => {
+  return fromTheme(`typography.${[attributeType]}`)({ theme })
+}
+
 export const focusStyle = () => ({
   theme,
 }: {

--- a/packages/asc-core/src/utils/themeUtils.ts
+++ b/packages/asc-core/src/utils/themeUtils.ts
@@ -13,13 +13,6 @@ export const getColorFromTheme = (
     : fromTheme('colors.tint.level1')({ theme })
 }
 
-export const getTypographyFromTheme = (
-  theme: Theme.ThemeInterface,
-  attributeType: string,
-) => {
-  return fromTheme(`typography.${[attributeType]}`)({ theme })
-}
-
 export const getFocusStyle = (theme: Theme.ThemeInterface) => css`
   &:focus {
     outline-color: ${getColorFromTheme(theme, 'support', 'focus')};

--- a/packages/asc-core/src/utils/themeUtils.ts
+++ b/packages/asc-core/src/utils/themeUtils.ts
@@ -3,6 +3,15 @@ import { css } from '../styled-components'
 import { Theme } from '../theme'
 import { fromTheme } from '.'
 
+export const color = (
+  colorType?: Theme.TypeLevel,
+  variant: string = 'main',
+) => ({ theme }: { theme: Theme.ThemeInterface }) => {
+  return colorType
+    ? fromTheme(`colors.${[colorType]}.${[variant]}`)({ theme })
+    : fromTheme('colors.tint.level1')({ theme })
+}
+
 export const getColorFromTheme = (
   theme: Theme.ThemeInterface,
   colorType?: Theme.TypeLevel,
@@ -13,13 +22,30 @@ export const getColorFromTheme = (
     : fromTheme('colors.tint.level1')({ theme })
 }
 
-export const getFocusStyle = (theme: Theme.ThemeInterface) => css`
+export const focusStyle = () => ({
+  theme,
+}: {
+  theme: Theme.ThemeInterface
+}) => css`
   &:focus {
-    outline-color: ${getColorFromTheme(theme, 'support', 'focus')};
+    outline-color: ${color('support', 'focus')({ theme })};
     outline-style: solid;
     outline-width: medium;
   }
 `
+export const breakpoint = (type: Theme.TypeBreakpoint, variant: string) => ({
+  theme,
+}: {
+  theme: Theme.ThemeInterface
+}) => {
+  const breakpoint: Theme.GetBreakpointFunc = fromTheme(
+    `breakpoints.${[variant]}`,
+  )({
+    theme,
+  })
+  return breakpoint && breakpoint(type)
+}
+
 export const getBreakpointFromTheme = (
   theme: Theme.ThemeInterface,
   type: Theme.TypeBreakpoint,
@@ -33,19 +59,18 @@ export const getBreakpointFromTheme = (
   return breakpoint && breakpoint(type)
 }
 
-export const fillSvgFromTheme = (
-  theme: Theme.ThemeInterface,
+export const svgFill = (
   colorType?: Theme.TypeLevel,
   variant: string = 'main',
-) => {
+) => ({ theme }: { theme: Theme.ThemeInterface }) => {
   if (colorType) {
-    const color = getColorFromTheme(theme, colorType, variant)
-    if (typeof color === 'string') {
+    const value = color(colorType, variant)({ theme })
+    if (typeof value === 'string') {
       return `
         rect,
         polygon,
         path {
-          fill: ${readableColor(color)}
+          fill: ${readableColor(value)}
         }
       `
     }


### PR DESCRIPTION
## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [x] The default export from a file matches the file name
- [x] The component styles are only placed in the `asc-core/src/components` folder. Exception is the `asc-ui/src/internals` folder where the styles are allowed. The components from this folder are just for internal use in the stories.
- [x] The component style name follows the pattern `<ComponentName>Style/<ComponentName>Style.ts`
- [x] Pull request has tests (we are going for 100% coverage!)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
