### PR TITLE
Readable color can't handle the Amsterdam red

### DIFF
--- a/packages/asc-core/src/utils/themeUtils.ts
+++ b/packages/asc-core/src/utils/themeUtils.ts
@@ -1,4 +1,3 @@
-import { readableColor } from 'polished'
 import { css } from '../styled-components'
 import { Theme } from '../theme'
 import { fromTheme } from '.'
@@ -64,7 +63,7 @@ export const svgFill = (
         rect,
         polygon,
         path {
-          fill: ${readableColor(value)}
+          fill: ${value}
         }
       `
     }


### PR DESCRIPTION
## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [ ] The default export from a file matches the file name
- [ ] The component styles are only placed in the `asc-core/src/components` folder. Exception is the `asc-ui/src/internals` folder where the styles are allowed. The components from this folder are just for internal use in the stories.
- [ ] The component style name follows the pattern `<ComponentName>Style/<ComponentName>Style.ts`
- [ ] Pull request has tests (we are going for 100% coverage!)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
