### PR TITLE
Added ImageCard components, moved 'strong' prop to typography

### DIFF
--- a/_templates/component/new/stories.ejs.t
+++ b/_templates/component/new/stories.ejs.t
@@ -7,7 +7,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import <%= name %> from './<%= name %>'
 
-storiesOf('<%= composed ? 'Composed' : 'Atom' %>/<%= name %>', module)
+storiesOf('<%= composed ? 'Composed' : 'Atoms' %>/<%= name %>', module)
   .add('default state', () => (
     <<%= name %> />
   ))

--- a/packages/asc-core/src/theme/default/typography.ts
+++ b/packages/asc-core/src/theme/default/typography.ts
@@ -26,7 +26,7 @@ const typography: Theme.TypographyInterface = {
     fontWeight: 700,
     letterSpacing: 'inherit',
     lineHeight: '28px',
-    marginBottom: '0',
+    marginBottom: '8px',
     breakpoints: {
       tabletS: {
         fontSize: '24px',

--- a/packages/asc-ui/src/components/CustomHTMLBlock/CustomHTMLBlockStyle.ts
+++ b/packages/asc-ui/src/components/CustomHTMLBlock/CustomHTMLBlockStyle.ts
@@ -29,5 +29,6 @@ export default styled.div`
   video {
     max-width: 100%;
     margin: 24px auto;
+    width: 100%;
   }
 `

--- a/packages/asc-ui/src/components/DocumentCover/__snapshots__/DocumentCover.test.tsx.snap
+++ b/packages/asc-ui/src/components/DocumentCover/__snapshots__/DocumentCover.test.tsx.snap
@@ -117,10 +117,7 @@ exports[`DocumentCover should render 1`] = `
 }
 
 .c6 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: 400;
   font-size: 14px;

--- a/packages/asc-ui/src/components/Grid/Container.tsx
+++ b/packages/asc-ui/src/components/Grid/Container.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import { ContainerStyle, ContainerWrapperStyle, Props } from './ContainerStyle'
 
-const Container: React.FC<Props> = ({ beamColor, children }) => (
-  <ContainerWrapperStyle>
+const Container: React.FC<Props & React.HTMLAttributes<HTMLDivElement>> = ({
+  beamColor,
+  children,
+  ...otherProps
+}) => (
+  <ContainerWrapperStyle {...otherProps}>
     <ContainerStyle beamColor={beamColor}>{children}</ContainerStyle>
   </ContainerWrapperStyle>
 )

--- a/packages/asc-ui/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/packages/asc-ui/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -45,10 +45,7 @@ exports[`Header should render the short version 1`] = `
 }
 
 .c8 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: inherit;
   font-size: 1rem;
@@ -326,10 +323,7 @@ exports[`Header should render the short version without the full width 1`] = `
 }
 
 .c8 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: inherit;
   font-size: 1rem;
@@ -624,10 +618,7 @@ exports[`Header should render the tall version 1`] = `
 }
 
 .c11 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: inherit;
   font-size: 1rem;

--- a/packages/asc-ui/src/components/Heading/Heading.tsx
+++ b/packages/asc-ui/src/components/Heading/Heading.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
-import HeadingStyle from './HeadingStyle'
+import HeadingStyle, { Props as HeadingStyleProps } from './HeadingStyle'
 
-const Heading: React.FC<
-  {
-    as?: keyof JSX.IntrinsicElements | React.ComponentType<any>
-  } & React.HTMLAttributes<HTMLHeadingElement>
-> = ({ children, className, as, ...otherProps }) => (
-  <HeadingStyle className={className} as={as} {...otherProps}>
+type Props = HeadingStyleProps & React.HTMLAttributes<HTMLHeadingElement>
+
+const Heading: React.FC<Props> = ({
+  children,
+  className,
+  as,
+  styleAs,
+  ...otherProps
+}) => (
+  <HeadingStyle {...{ styleAs, as, className }} {...otherProps}>
     {children}
   </HeadingStyle>
 )

--- a/packages/asc-ui/src/components/Heading/HeadingStyle.ts
+++ b/packages/asc-ui/src/components/Heading/HeadingStyle.ts
@@ -1,7 +1,9 @@
 import styled, { css, styledComponents } from '@datapunt/asc-core'
-import TypographyStyle from '../Typography/TypographyStyle'
+import TypographyStyle, {
+  Props as TypographyProps,
+} from '../Typography/TypographyStyle'
 
-type Props = {} & styledComponents.StyledProps<any>
+export type Props = TypographyProps & styledComponents.StyledProps<any>
 
 export const HeaderStyleCSS = css`
   margin-top: 0;

--- a/packages/asc-ui/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/packages/asc-ui/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -3,10 +3,7 @@
 exports[`Heading should render 1`] = `
 Array [
   .c0 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: 700;
   font-size: 24px;
@@ -52,10 +49,7 @@ Array [
     Foo
   </h1>,
   .c0 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: 700;
   font-size: 20px;
@@ -101,10 +95,7 @@ Array [
     Foo
   </h2>,
   .c0 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: 700;
   font-size: 20px;
@@ -143,10 +134,7 @@ Array [
     Foo
   </h3>,
   .c0 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: 700;
   font-size: 18px;

--- a/packages/asc-ui/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/packages/asc-ui/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -64,7 +64,7 @@ Array [
   -ms-letter-spacing: inherit;
   letter-spacing: inherit;
   line-height: 28px;
-  margin-bottom: 0;
+  margin-bottom: 8px;
   font-stretch: normal;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;

--- a/packages/asc-ui/src/components/ImageCard/ImageCard.stories.tsx
+++ b/packages/asc-ui/src/components/ImageCard/ImageCard.stories.tsx
@@ -11,7 +11,7 @@ import { breakpoint } from '../../utils'
 import { ImageCardWrapperStyle } from './ImageCardStyle'
 import TypographyStyle from '../Typography/TypographyStyle'
 
-const ImageCardConstainer = styled.section`
+const ImageCardContainer = styled.section`
   width: calc(100% + 24px);
   margin-left: -12px;
   margin-right: -12px;
@@ -88,7 +88,7 @@ storiesOf('Atoms/ImageCard', module)
           <Heading as="h6" styleAs="h2">
             Jeugdwerkloosheid Amsterdam daalt naar 6,2%
           </Heading>
-          <Paragraph skipAutoMargin>
+          <Paragraph gutterBottom={0}>
             Amsterdamse jongeren even vaak werkloos als gemiddeld in Nederland
           </Paragraph>
         </ImageCardContent>
@@ -99,7 +99,7 @@ storiesOf('Atoms/ImageCard', module)
     <Row>
       <Column wrap span={{ small: 1, medium: 2, big: 6, large: 8, xLarge: 8 }}>
         <div style={{ width: '100%' }}>
-          <ImageCardConstainer>
+          <ImageCardContainer>
             <ImageCardWrapperBig>
               <ImageCard
                 margin={12}
@@ -109,7 +109,7 @@ storiesOf('Atoms/ImageCard', module)
                   <Heading as="h6" styleAs="h2">
                     Jeugdwerkloosheid Amsterdam daalt naar 6,2%
                   </Heading>
-                  <Paragraph skipAutoMargin>
+                  <Paragraph gutterBottom={0}>
                     Amsterdamse jongeren even vaak werkloos als gemiddeld in
                     Nederland
                   </Paragraph>
@@ -122,7 +122,7 @@ storiesOf('Atoms/ImageCard', module)
                 backgroundImage="http://lorempixel.com/output/food-q-c-640-480-3.jpg"
               >
                 <ImageCardContent>
-                  <Heading as="h6" strong skipAutoMargin styleAs="p">
+                  <Heading as="h6" strong gutterBottom={0} styleAs="p">
                     Jeugdwerk&shy;loosheid Amsterdam daalt naar 6,2%
                   </Heading>
                 </ImageCardContent>
@@ -132,13 +132,13 @@ storiesOf('Atoms/ImageCard', module)
                 backgroundImage="http://lorempixel.com/output/food-q-c-640-480-3.jpg"
               >
                 <ImageCardContent>
-                  <Heading as="h6" strong skipAutoMargin styleAs="p">
+                  <Heading as="h6" strong gutterBottom={0} styleAs="p">
                     Amsterdammers voelen zich veiliger in het OV
                   </Heading>
                 </ImageCardContent>
               </ImageCard>
             </ImageCardWrapperSmall>
-          </ImageCardConstainer>
+          </ImageCardContainer>
         </div>
       </Column>
     </Row>

--- a/packages/asc-ui/src/components/ImageCard/ImageCard.stories.tsx
+++ b/packages/asc-ui/src/components/ImageCard/ImageCard.stories.tsx
@@ -1,0 +1,145 @@
+import React from 'react'
+import styled from '@datapunt/asc-core'
+import { storiesOf } from '@storybook/react'
+import ImageCard from './ImageCard'
+import { ImageCardContent } from './ImageCardContent'
+import Heading from '../Heading'
+import Paragraph from '../Paragraph'
+import Row from '../Grid/Row'
+import Column from '../Grid/Column'
+import { breakpoint } from '../../utils'
+import { ImageCardWrapperStyle } from './ImageCardStyle'
+import TypographyStyle from '../Typography/TypographyStyle'
+
+const ImageCardConstainer = styled.section`
+  width: calc(100% + 24px);
+  margin-left: -12px;
+  margin-right: -12px;
+  display: flex;
+  flex-wrap: wrap;
+
+  @media screen and ${breakpoint('min-width', 'laptop')} {
+    width: calc(100% + 4px);
+  }
+`
+const ImageCardWrapperBig = styled.div`
+  flex-basis: 100%;
+  @media screen and ${breakpoint('min-width', 'tabletM')} {
+    flex-basis: ${100 - 100 / 3}%;
+  }
+`
+const ImageCardWrapperSmall = styled.div`
+  justify-content: space-around;
+  display: flex;
+  flex-wrap: wrap;
+  flex-basis: 100%;
+
+  ${ImageCardWrapperStyle} {
+    flex-basis: 100%;
+    @media screen and ${breakpoint('min-width', 'mobileL')} {
+      flex-basis: calc(50% - 24px);
+    }
+    @media screen and ${breakpoint('min-width', 'tabletM')} {
+      flex-basis: 100%;
+    }
+  }
+
+  @media screen and ${breakpoint('min-width', 'tabletM')} {
+    flex-wrap: nowrap;
+    flex-basis: ${100 / 3}%;
+    flex-direction: column;
+
+    ${ImageCardWrapperStyle} {
+      flex-basis: 100%;
+    }
+  }
+
+  ${TypographyStyle} {
+    @media screen and ${breakpoint('min-width', 'tabletM')} {
+      line-height: inherit;
+      font-size: inherit;
+    }
+    @media screen and ${breakpoint('max-width', 'tabletM')} {
+      line-height: 20px;
+      font-size: 14px;
+    }
+  }
+`
+
+storiesOf('Atoms/ImageCard', module)
+  .add('default state', () => (
+    <div style={{ maxWidth: '600px' }}>
+      <ImageCard backgroundImage="http://lorempixel.com/output/food-q-c-640-480-3.jpg">
+        <ImageCardContent>
+          <Heading as="h6" styleAs="h2">
+            Jeugdwerkloosheid Amsterdam daalt naar 6,2%
+          </Heading>
+        </ImageCardContent>
+      </ImageCard>
+    </div>
+  ))
+  .add('loading state', () => (
+    <div style={{ maxWidth: '600px' }}>
+      <ImageCard
+        loading
+        backgroundImage="http://lorempixel.com/output/food-q-c-640-480-3.jpg"
+      >
+        <ImageCardContent>
+          <Heading as="h6" styleAs="h2">
+            Jeugdwerkloosheid Amsterdam daalt naar 6,2%
+          </Heading>
+          <Paragraph skipAutoMargin>
+            Amsterdamse jongeren even vaak werkloos als gemiddeld in Nederland
+          </Paragraph>
+        </ImageCardContent>
+      </ImageCard>
+    </div>
+  ))
+  .add('dataportaal implementation', () => (
+    <Row>
+      <Column wrap span={{ small: 1, medium: 2, big: 6, large: 8, xLarge: 8 }}>
+        <div style={{ width: '100%' }}>
+          <ImageCardConstainer>
+            <ImageCardWrapperBig>
+              <ImageCard
+                margin={12}
+                backgroundImage="http://lorempixel.com/output/food-q-c-640-480-3.jpg"
+              >
+                <ImageCardContent>
+                  <Heading as="h6" styleAs="h2">
+                    Jeugdwerkloosheid Amsterdam daalt naar 6,2%
+                  </Heading>
+                  <Paragraph skipAutoMargin>
+                    Amsterdamse jongeren even vaak werkloos als gemiddeld in
+                    Nederland
+                  </Paragraph>
+                </ImageCardContent>
+              </ImageCard>
+            </ImageCardWrapperBig>
+            <ImageCardWrapperSmall>
+              <ImageCard
+                margin={12}
+                backgroundImage="http://lorempixel.com/output/food-q-c-640-480-3.jpg"
+              >
+                <ImageCardContent>
+                  <Heading as="h6" strong skipAutoMargin styleAs="p">
+                    Jeugdwerk&shy;loosheid Amsterdam daalt naar 6,2%
+                  </Heading>
+                </ImageCardContent>
+              </ImageCard>
+              <ImageCard
+                margin={12}
+                backgroundImage="http://lorempixel.com/output/food-q-c-640-480-3.jpg"
+              >
+                <ImageCardContent>
+                  <Heading as="h6" strong skipAutoMargin styleAs="p">
+                    Amsterdammers voelen zich veiliger in het OV
+                  </Heading>
+                </ImageCardContent>
+              </ImageCard>
+            </ImageCardWrapperSmall>
+          </ImageCardConstainer>
+        </div>
+      </Column>
+    </Row>
+  ))

--- a/packages/asc-ui/src/components/ImageCard/ImageCard.test.tsx
+++ b/packages/asc-ui/src/components/ImageCard/ImageCard.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { renderWithTheme } from '../../utils/withTheme'
+import ImageCard from './ImageCard'
+import Heading from '../Heading'
+import ImageCardContent from './ImageCardContent/ImageCardContent'
+import 'jest-styled-components'
+
+describe('ImageCard', () => {
+  it('should render', () => {
+    const component = renderWithTheme(
+      <ImageCard backgroundImage="https://www.example.com">
+        <ImageCardContent>
+          <Heading as="h6" styleAs="h2">
+            Jeugdwerkloosheid Amsterdam daalt naar 6,2%
+          </Heading>
+        </ImageCardContent>
+      </ImageCard>,
+    )
+
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/packages/asc-ui/src/components/ImageCard/ImageCard.tsx
+++ b/packages/asc-ui/src/components/ImageCard/ImageCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import ImageCardStyle, {
+  ImageCardWrapperStyle,
+  WrapperProps,
+  Props,
+} from './ImageCardStyle'
+
+const ImageCard: React.FC<
+  Props & WrapperProps & React.HTMLAttributes<HTMLElement>
+> = ({ children, backgroundImage, margin, ...otherProps }) => (
+  <ImageCardWrapperStyle margin={margin}>
+    <ImageCardStyle backgroundImage={backgroundImage} {...otherProps}>
+      {children}
+    </ImageCardStyle>
+  </ImageCardWrapperStyle>
+)
+
+export default ImageCard

--- a/packages/asc-ui/src/components/ImageCard/ImageCardContent/ImageCardContent.tsx
+++ b/packages/asc-ui/src/components/ImageCard/ImageCardContent/ImageCardContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import ImageCardContentStyle, { Props } from './ImageCardContentStyle'
+import ImageCardContentStyle from './ImageCardContentStyle'
 
-const ImageCardContent: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
+const ImageCardContent: React.FC<React.HTMLAttributes<HTMLElement>> = ({
   children,
   ...otherProps
 }) => <ImageCardContentStyle {...otherProps}>{children}</ImageCardContentStyle>

--- a/packages/asc-ui/src/components/ImageCard/ImageCardContent/ImageCardContent.tsx
+++ b/packages/asc-ui/src/components/ImageCard/ImageCardContent/ImageCardContent.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ImageCardContentStyle, { Props } from './ImageCardContentStyle'
+
+const ImageCardContent: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
+  children,
+  ...otherProps
+}) => <ImageCardContentStyle {...otherProps}>{children}</ImageCardContentStyle>
+
+export default ImageCardContent

--- a/packages/asc-ui/src/components/ImageCard/ImageCardContent/ImageCardContentStyle.ts
+++ b/packages/asc-ui/src/components/ImageCard/ImageCardContent/ImageCardContentStyle.ts
@@ -1,0 +1,18 @@
+import styled from '@datapunt/asc-core'
+import { color, breakpoint } from '../../../utils'
+
+export type Props = {}
+
+export default styled.div<Props>`
+  padding: 8px 14px;
+  background-color: ${color('tint', 'level1')};
+  position: absolute;
+  bottom: 56px;
+  left: 0;
+  max-width: calc(100% - 44px);
+  word-break: break-word;
+
+  @media screen and ${breakpoint('min-width', 'tabletM')} {
+    padding: 16px;
+  }
+`

--- a/packages/asc-ui/src/components/ImageCard/ImageCardContent/ImageCardContentStyle.ts
+++ b/packages/asc-ui/src/components/ImageCard/ImageCardContent/ImageCardContentStyle.ts
@@ -1,9 +1,7 @@
 import styled from '@datapunt/asc-core'
 import { color, breakpoint } from '../../../utils'
 
-export type Props = {}
-
-export default styled.div<Props>`
+export default styled.div`
   padding: 8px 14px;
   background-color: ${color('tint', 'level1')};
   position: absolute;

--- a/packages/asc-ui/src/components/ImageCard/ImageCardContent/index.ts
+++ b/packages/asc-ui/src/components/ImageCard/ImageCardContent/index.ts
@@ -1,0 +1,2 @@
+export { default as ImageCardContentStyle } from './ImageCardContentStyle'
+export { default as ImageCardContent } from './ImageCardContent'

--- a/packages/asc-ui/src/components/ImageCard/ImageCardStyle.ts
+++ b/packages/asc-ui/src/components/ImageCard/ImageCardStyle.ts
@@ -1,0 +1,67 @@
+import styled, { css } from '@datapunt/asc-core'
+import { perceivedLoading } from '../../utils/themeUtils'
+import { ImageCardContentStyle } from './ImageCardContent'
+
+export type Props = {
+  backgroundImage: string
+  loading?: boolean
+}
+
+export type WrapperProps = {
+  margin?: number
+}
+
+export const ImageCardWrapperStyle = styled.div<WrapperProps>`
+  ${({ margin }) =>
+    margin &&
+    css`
+      margin: ${margin}px;
+    `}
+`
+
+export default styled.div<Props>`
+  padding-top: 100%;
+  background-size: cover;
+  background-repeat: no-repeat;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  ${({ loading, theme, backgroundImage }) =>
+    loading
+      ? css`
+          ${perceivedLoading(theme)}
+          ${ImageCardContentStyle} {
+            height: 100px;
+            width: 100%;
+
+            & > * {
+              display: none;
+            }
+
+            &::before {
+              content: '';
+              display: block;
+              width: 380px;
+              height: 30px;
+              ${perceivedLoading(theme)}
+            }
+          }
+        `
+      : css`
+          background-image: url(${backgroundImage});
+        `}
+
+  &::before {
+    content: '';
+    width: 0;
+    height: 0;
+    border-width: 22px;
+    border-color: transparent;
+    position: absolute;
+    border-style: solid;
+    right: 0;
+    bottom: 0;
+    border-bottom-color: white;
+    border-right-color: white;
+  }
+`

--- a/packages/asc-ui/src/components/ImageCard/__snapshots__/ImageCard.test.tsx.snap
+++ b/packages/asc-ui/src/components/ImageCard/__snapshots__/ImageCard.test.tsx.snap
@@ -2,10 +2,7 @@
 
 exports[`ImageCard should render 1`] = `
 .c2 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: 700;
   font-size: 20px;

--- a/packages/asc-ui/src/components/ImageCard/__snapshots__/ImageCard.test.tsx.snap
+++ b/packages/asc-ui/src/components/ImageCard/__snapshots__/ImageCard.test.tsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ImageCard should render 1`] = `
+.c2 {
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  color: #000000;
+  font-weight: 700;
+  font-size: 20px;
+  -webkit-letter-spacing: inherit;
+  -moz-letter-spacing: inherit;
+  -ms-letter-spacing: inherit;
+  letter-spacing: inherit;
+  line-height: 28px;
+  margin-bottom: 8px;
+  font-stretch: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c1 {
+  padding: 8px 14px;
+  background-color: #ffffff;
+  position: absolute;
+  bottom: 56px;
+  left: 0;
+  max-width: calc(100% - 44px);
+  word-break: break-word;
+}
+
+.c0 {
+  padding-top: 100%;
+  background-size: cover;
+  background-repeat: no-repeat;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  background-image: url(https://www.example.com);
+}
+
+.c0::before {
+  content: '';
+  width: 0;
+  height: 0;
+  border-width: 22px;
+  border-color: transparent;
+  position: absolute;
+  border-style: solid;
+  right: 0;
+  bottom: 0;
+  border-bottom-color: white;
+  border-right-color: white;
+}
+
+@media screen and (min-width:540.02px) {
+  .c2 {
+    font-size: 24px;
+    line-height: 30px;
+  }
+}
+
+@media screen and (min-width:768.02px) {
+  .c1 {
+    padding: 16px;
+  }
+}
+
+<div
+  class=""
+>
+  <div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <h6
+        class="c2"
+      >
+        Jeugdwerkloosheid Amsterdam daalt naar 6,2%
+      </h6>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/asc-ui/src/components/ImageCard/index.ts
+++ b/packages/asc-ui/src/components/ImageCard/index.ts
@@ -1,0 +1,11 @@
+import { ImageCardContent, ImageCardContentStyle } from './ImageCardContent'
+import ImageCardStyle from './ImageCardStyle'
+
+export { default } from './ImageCard'
+
+export { ImageCardContent }
+
+export const ImageCardStyles = {
+  ImageCardContentStyle,
+  ImageCardStyle,
+}

--- a/packages/asc-ui/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/asc-ui/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -2,10 +2,7 @@
 
 exports[`Link should render 1`] = `
 .c0 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: inherit;
   font-size: 1rem;

--- a/packages/asc-ui/src/components/Paragraph/ParagraphStyle.ts
+++ b/packages/asc-ui/src/components/Paragraph/ParagraphStyle.ts
@@ -28,5 +28,5 @@ export const ParagraphStyleCSS = css<Props>`
 `
 
 export default styled(TypographyStyle)<Props>`
-  ${ParagraphStyleCSS}
+  ${ParagraphStyleCSS};
 `

--- a/packages/asc-ui/src/components/Paragraph/ParagraphStyle.ts
+++ b/packages/asc-ui/src/components/Paragraph/ParagraphStyle.ts
@@ -1,11 +1,12 @@
 import styled, { css } from '@datapunt/asc-core'
-import TypographyStyle from '../Typography/TypographyStyle'
+import TypographyStyle, {
+  Props as TypographyProps,
+} from '../Typography/TypographyStyle'
 import { breakpoint, color } from '../../utils'
 
 export type Props = {
   hasLongText?: boolean
-  strong?: boolean
-}
+} & TypographyProps
 
 export const ParagraphStyleCSS = css<Props>`
   margin-top: 0;

--- a/packages/asc-ui/src/components/Paragraph/__snapshots__/Paragraph.test.tsx.snap
+++ b/packages/asc-ui/src/components/Paragraph/__snapshots__/Paragraph.test.tsx.snap
@@ -2,10 +2,7 @@
 
 exports[`Paragraph should render 1`] = `
 .c0 {
-  margin-top: 0;
-  margin-right: 0;
-  margin-bottom: 0;
-  margin-left: 0;
+  margin: 0;
   color: #000000;
   font-weight: 400;
   font-size: 16px;

--- a/packages/asc-ui/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/asc-ui/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`<TextField /> should render 1`] = `
           "fontWeight": 700,
           "letterSpacing": "inherit",
           "lineHeight": "28px",
-          "marginBottom": "0",
+          "marginBottom": "8px",
         },
         "h3": Object {
           "defaultColor": "#000000",

--- a/packages/asc-ui/src/components/Typography/TypographyStyle.ts
+++ b/packages/asc-ui/src/components/Typography/TypographyStyle.ts
@@ -1,6 +1,5 @@
 import styled, { css, styledComponents, Theme } from '@datapunt/asc-core'
-import { em, margin } from 'polished'
-import { getTypographyFromTheme, color as getColor, color } from '../../utils'
+import { getTypographyFromTheme, color } from '../../utils'
 
 import TypographyElements = Theme.TypographyElements
 
@@ -11,7 +10,6 @@ export type Props = {
   color?: Theme.TypeLevel
   fontSize?: number
   styleAs?: keyof TypographyElements
-  skipAutoMargin?: boolean
   strong?: boolean
 } & styledComponents.StyledProps<any>
 
@@ -26,8 +24,8 @@ export type Variant = keyof typeof defaultTypographyStyles
 const getProperty = <T, K extends keyof T>(obj: T, key: K) => obj[key]
 
 export default styled.p<Props>`
-  ${({ as }) => getProperty(defaultTypographyStyles, as)}
-  ${margin(0)};
+  ${({ as }) => getProperty(defaultTypographyStyles, as)};
+  margin: 0;
   ${getTypographyFromTheme()};
   font-stretch: normal;
   letter-spacing: normal;
@@ -37,15 +35,10 @@ export default styled.p<Props>`
       font-weight: 700;
       color: ${color('tint', 'level7')};
     `}
-  ${({ gutterBottom }) =>
-    gutterBottom &&
-    css`
-      margin-bottom: ${em(`${gutterBottom}px`)};
-    `}
   ${({ color: colorProp }) =>
     colorProp &&
     css`
-      color: ${getColor(colorProp)};
+      color: ${color(colorProp)};
     `}
   ${({ fontSize }) =>
     fontSize &&

--- a/packages/asc-ui/src/components/Typography/TypographyStyle.ts
+++ b/packages/asc-ui/src/components/Typography/TypographyStyle.ts
@@ -1,6 +1,8 @@
 import styled, { css, styledComponents, Theme } from '@datapunt/asc-core'
 import { em, margin } from 'polished'
-import { getTypographyFromTheme, color as getColor } from '../../utils'
+import { getTypographyFromTheme, color as getColor, color } from '../../utils'
+
+import TypographyElements = Theme.TypographyElements
 
 export type Props = {
   gutterBottom?: number
@@ -8,6 +10,9 @@ export type Props = {
   element?: Variant
   color?: Theme.TypeLevel
   fontSize?: number
+  styleAs?: keyof TypographyElements
+  skipAutoMargin?: boolean
+  strong?: boolean
 } & styledComponents.StyledProps<any>
 
 export const defaultTypographyStyles = {
@@ -26,19 +31,25 @@ export default styled.p<Props>`
   ${getTypographyFromTheme()};
   font-stretch: normal;
   letter-spacing: normal;
+  ${({ strong }) =>
+    strong &&
+    css`
+      font-weight: 700;
+      color: ${color('tint', 'level7')};
+    `}
   ${({ gutterBottom }) =>
     gutterBottom &&
     css`
       margin-bottom: ${em(`${gutterBottom}px`)};
     `}
-  ${({ color }) =>
-    color &&
+  ${({ color: colorProp }) =>
+    colorProp &&
     css`
-      color: ${getColor(color)};
+      color: ${getColor(colorProp)};
     `}
   ${({ fontSize }) =>
     fontSize &&
     css`
       font-size: ${fontSize}px;
-    `}
+    `} 
 `

--- a/packages/asc-ui/src/index.ts
+++ b/packages/asc-ui/src/index.ts
@@ -32,6 +32,10 @@ import SearchBarToggle, {
 } from './components/SearchBarToggle'
 import TextField, { TextFieldStyles } from './components/TextField'
 import GlobalStyle from './components/GlobalStyle'
+import ImageCard, {
+  ImageCardContent,
+  ImageCardStyles,
+} from './components/ImageCard'
 import {
   GridContainer,
   GridItem,
@@ -79,6 +83,7 @@ export const styles = {
   ...SearchBarToggleStyles,
   ...MenuStyles,
   ...BlogStyles,
+  ...ImageCardStyles,
   CustomHTMLBlockStyle,
   ArticleStyle,
 }
@@ -105,6 +110,8 @@ export {
   Divider,
   IconButton,
   Input,
+  ImageCard,
+  ImageCardContent,
   ListItem,
   MenuFlyOut,
   MenuInline,

--- a/packages/asc-ui/src/utils/themeUtils.ts
+++ b/packages/asc-ui/src/utils/themeUtils.ts
@@ -1,4 +1,4 @@
-import { css, Theme } from '@datapunt/asc-core'
+import { css, keyframes, Theme } from '@datapunt/asc-core'
 import { fromTheme } from '.'
 
 import BreakpointsInterface = Theme.BreakpointsInterface
@@ -41,23 +41,32 @@ export const breakpoint = (
   return breakpointFunc && breakpointFunc(type)
 }
 
-const generateCSSFromTypography = ({
-  defaultColor,
-  fontWeight,
-  fontSize,
-  letterSpacing,
-  lineHeight,
-  marginBottom,
-}: any) => css`
+const generateCSSFromTypography = (
+  {
+    defaultColor,
+    fontWeight,
+    fontSize,
+    letterSpacing,
+    lineHeight,
+    marginBottom,
+  }: any,
+  skipAutoMargin?: boolean,
+) => css`
   color: ${defaultColor};
   font-weight: ${fontWeight};
   font-size: ${fontSize};
   letter-spacing: ${letterSpacing};
   line-height: ${lineHeight};
-  margin-bottom: ${marginBottom};
+  margin-bottom: ${skipAutoMargin ? 0 : marginBottom};
 `
 
-export const getTypographyFromTheme = () => ({ as = 'p', theme }: any) => {
+export const getTypographyFromTheme = () => ({
+  as: asProp = 'p',
+  skipAutoMargin,
+  styleAs,
+  theme,
+}: any) => {
+  const as = styleAs || asProp
   const {
     defaultColor,
     fontWeight,
@@ -68,14 +77,17 @@ export const getTypographyFromTheme = () => ({ as = 'p', theme }: any) => {
     breakpoints,
   } = fromTheme(`typography.${[as]}`)({ theme })
   return css`
-    ${generateCSSFromTypography({
-      defaultColor,
-      fontWeight,
-      fontSize,
-      letterSpacing,
-      lineHeight,
-      marginBottom,
-    })}
+    ${generateCSSFromTypography(
+      {
+        defaultColor,
+        fontWeight,
+        fontSize,
+        letterSpacing,
+        lineHeight,
+        marginBottom,
+      },
+      skipAutoMargin,
+    )}
     ${() =>
       breakpoints
         ? Object.entries(breakpoints).map(
@@ -83,7 +95,7 @@ export const getTypographyFromTheme = () => ({ as = 'p', theme }: any) => {
               @media screen and ${breakpoint('min-width', <
                   keyof BreakpointsInterface
                 >breakpointFromTypography)} {
-                ${generateCSSFromTypography(styles)}
+                ${generateCSSFromTypography(styles, skipAutoMargin)}
               }
             `,
           )
@@ -161,6 +173,34 @@ export const svgFill = (
   }
 
   return ''
+}
+
+/**
+ * Use this util to animate the background-color (or other property), for perceived performance purposes
+ * @param theme
+ * @param property
+ */
+export const perceivedLoading = (
+  theme: ThemeInterface,
+  property: string = 'background-color',
+) => {
+  const animation = keyframes`
+    0% {
+      ${property}: ${color('tint', 'level3')({ theme })};
+    }
+  
+    50% {
+      ${property}: ${color('tint', 'level4')({ theme })};
+    }
+    
+    100% {
+      ${property}: ${color('tint', 'level3')({ theme })};
+    }
+  `
+
+  return css`
+    animation: ${animation} 2s ease-in-out infinite;
+  `
 }
 
 export const mapToBreakpoints = (

--- a/packages/asc-ui/src/utils/themeUtils.ts
+++ b/packages/asc-ui/src/utils/themeUtils.ts
@@ -50,19 +50,21 @@ const generateCSSFromTypography = (
     lineHeight,
     marginBottom,
   }: any,
-  skipAutoMargin?: boolean,
+  gutterBottom?: boolean,
 ) => css`
   color: ${defaultColor};
   font-weight: ${fontWeight};
   font-size: ${fontSize};
   letter-spacing: ${letterSpacing};
   line-height: ${lineHeight};
-  margin-bottom: ${skipAutoMargin ? 0 : marginBottom};
+  margin-bottom: ${typeof gutterBottom === 'number'
+    ? gutterBottom
+    : marginBottom};
 `
 
 export const getTypographyFromTheme = () => ({
   as: asProp = 'p',
-  skipAutoMargin,
+  gutterBottom,
   styleAs,
   theme,
 }: any) => {
@@ -86,7 +88,7 @@ export const getTypographyFromTheme = () => ({
         lineHeight,
         marginBottom,
       },
-      skipAutoMargin,
+      gutterBottom,
     )}
     ${() =>
       breakpoints
@@ -95,7 +97,7 @@ export const getTypographyFromTheme = () => ({
               @media screen and ${breakpoint('min-width', <
                   keyof BreakpointsInterface
                 >breakpointFromTypography)} {
-                ${generateCSSFromTypography(styles, skipAutoMargin)}
+                ${generateCSSFromTypography(styles, gutterBottom)}
               }
             `,
           )


### PR DESCRIPTION
## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [x] The default export from a file matches the file name
- [x] The component styles are only placed in the `asc-core/src/components` folder. Exception is the `asc-ui/src/internals` folder where the styles are allowed. The components from this folder are just for internal use in the stories.
- [x] The component style name follows the pattern `<ComponentName>Style/<ComponentName>Style.ts`
- [x] Pull request has tests (we are going for 100% coverage!)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
