### PR TITLE
Renamed ToggleHeader -> ToggleHandler, fixed svg fill and header issues

### DIFF
--- a/packages/asc-ui/src/components/DocumentCover/__snapshots__/DocumentCover.test.tsx.snap
+++ b/packages/asc-ui/src/components/DocumentCover/__snapshots__/DocumentCover.test.tsx.snap
@@ -33,9 +33,9 @@ exports[`DocumentCover should render 1`] = `
   height: inherit;
 }
 
-.c5 > svg rect,
-.c5 > svg polygon,
-.c5 > svg path {
+.c5 svg rect,
+.c5 svg polygon,
+.c5 svg path {
   fill: #ffffff;
 }
 

--- a/packages/asc-ui/src/components/Footer/FooterHeading/FooterToggle.tsx
+++ b/packages/asc-ui/src/components/Footer/FooterHeading/FooterToggle.tsx
@@ -14,7 +14,7 @@ const FooterToggle: React.FC<Props> = ({ title, children, ...otherProps }) => {
   `
   return (
     <StyledFooterToggle
-      ToggleHeader={ToggleFooterHeader}
+      ToggleHandler={ToggleFooterHeader}
       title={title}
       align="left"
       {...otherProps}

--- a/packages/asc-ui/src/components/Footer/FooterHeading/ToggleFooterHeader.tsx
+++ b/packages/asc-ui/src/components/Footer/FooterHeading/ToggleFooterHeader.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import styled from '@datapunt/asc-core'
 import { ChevronDown, ChevronUp } from '@datapunt/asc-assets'
 import Icon from '../../Icon'
-import { ToggleHeaderProps } from '../../Toggle'
+import { ToggleHandlerProps } from '../../Toggle'
 import IconStyle from '../../Icon/IconStyle'
 import FooterHeading from './FooterHeading'
 import { svgFill } from '../../../utils'
 
-export type Props = ToggleHeaderProps
+export type Props = ToggleHandlerProps
 
 const ToggleFooterHeader: React.FC<Props> = ({ open, onClick, title }) => {
   const IconOpen = <ChevronDown />

--- a/packages/asc-ui/src/components/Header/HeaderStyle.ts
+++ b/packages/asc-ui/src/components/Header/HeaderStyle.ts
@@ -9,7 +9,6 @@ export type HeaderStyleProps = {
 const HeaderStyle = styled(TopBarStyle)<HeaderStyleProps>`
   flex-wrap: nowrap;
   height: 100%;
-  min-height: 50px;
   margin: 0 auto;
   padding: 0 10px;
   align-items: stretch;

--- a/packages/asc-ui/src/components/Header/HeaderWrapperStyle.ts
+++ b/packages/asc-ui/src/components/Header/HeaderWrapperStyle.ts
@@ -18,6 +18,7 @@ const shortStyle = css`
   }
 
   ${HeaderStyle} {
+    min-height: 50px;
     padding-right: 0; /* collapse to the right side to align navigation items to the edge */
   }
 `

--- a/packages/asc-ui/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/packages/asc-ui/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`Header should render the short version 1`] = `
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   height: 100%;
-  min-height: 50px;
   margin: 0 auto;
   padding: 0 10px;
   -webkit-align-items: stretch;
@@ -168,6 +167,7 @@ exports[`Header should render the short version 1`] = `
 }
 
 .c0 .c1 {
+  min-height: 50px;
   padding-right: 0;
 }
 
@@ -208,12 +208,12 @@ exports[`Header should render the short version 1`] = `
   color: #ec0000;
 }
 
-.c11 .c14:focus > svg rect,
-.c11 .c14:hover > svg rect,
-.c11 .c14:focus > svg polygon,
-.c11 .c14:hover > svg polygon,
-.c11 .c14:focus > svg path,
-.c11 .c14:hover > svg path {
+.c11 .c14:focus svg rect,
+.c11 .c14:hover svg rect,
+.c11 .c14:focus svg polygon,
+.c11 .c14:hover svg polygon,
+.c11 .c14:focus svg path,
+.c11 .c14:hover svg path {
   fill: #ec0000;
 }
 
@@ -297,7 +297,6 @@ exports[`Header should render the short version without the full width 1`] = `
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   height: 100%;
-  min-height: 50px;
   margin: 0 auto;
   padding: 0 10px;
   -webkit-align-items: stretch;
@@ -431,6 +430,7 @@ exports[`Header should render the short version without the full width 1`] = `
 }
 
 .c12 .c1 {
+  min-height: 50px;
   padding-right: 0;
 }
 
@@ -462,6 +462,7 @@ exports[`Header should render the short version without the full width 1`] = `
 }
 
 .c0 .c1 {
+  min-height: 50px;
   padding-right: 0;
 }
 
@@ -502,12 +503,12 @@ exports[`Header should render the short version without the full width 1`] = `
   color: #ec0000;
 }
 
-.c11 .c15:focus > svg rect,
-.c11 .c15:hover > svg rect,
-.c11 .c15:focus > svg polygon,
-.c11 .c15:hover > svg polygon,
-.c11 .c15:focus > svg path,
-.c11 .c15:hover > svg path {
+.c11 .c15:focus svg rect,
+.c11 .c15:hover svg rect,
+.c11 .c15:focus svg polygon,
+.c11 .c15:hover svg polygon,
+.c11 .c15:focus svg path,
+.c11 .c15:hover svg path {
   fill: #ec0000;
 }
 
@@ -591,7 +592,6 @@ exports[`Header should render the tall version 1`] = `
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   height: 100%;
-  min-height: 50px;
   margin: 0 auto;
   padding: 0 10px;
   -webkit-align-items: stretch;
@@ -730,6 +730,7 @@ exports[`Header should render the tall version 1`] = `
 }
 
 .c16 .c2 {
+  min-height: 50px;
   padding-right: 0;
 }
 
@@ -746,6 +747,7 @@ exports[`Header should render the tall version 1`] = `
 }
 
 .c17 .c2 {
+  min-height: 50px;
   padding-right: 0;
 }
 
@@ -809,12 +811,12 @@ exports[`Header should render the tall version 1`] = `
   color: #ec0000;
 }
 
-.c14 .c20:focus > svg rect,
-.c14 .c20:hover > svg rect,
-.c14 .c20:focus > svg polygon,
-.c14 .c20:hover > svg polygon,
-.c14 .c20:focus > svg path,
-.c14 .c20:hover > svg path {
+.c14 .c20:focus svg rect,
+.c14 .c20:hover svg rect,
+.c14 .c20:focus svg polygon,
+.c14 .c20:hover svg polygon,
+.c14 .c20:focus svg path,
+.c14 .c20:hover svg path {
   fill: #ec0000;
 }
 
@@ -863,6 +865,7 @@ exports[`Header should render the tall version 1`] = `
   }
 
   .c0 .c2 {
+    min-height: 50px;
     padding-right: 0;
   }
 }
@@ -976,7 +979,6 @@ exports[`Header should render the tall version without a title 1`] = `
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   height: 100%;
-  min-height: 50px;
   margin: 0 auto;
   padding: 0 10px;
   -webkit-align-items: stretch;
@@ -1081,6 +1083,7 @@ exports[`Header should render the tall version without a title 1`] = `
 }
 
 .c14 .c2 {
+  min-height: 50px;
   padding-right: 0;
 }
 
@@ -1093,6 +1096,7 @@ exports[`Header should render the tall version without a title 1`] = `
 }
 
 .c15 .c2 {
+  min-height: 50px;
   padding-right: 0;
 }
 
@@ -1156,12 +1160,12 @@ exports[`Header should render the tall version without a title 1`] = `
   color: #ec0000;
 }
 
-.c12 .c18:focus > svg rect,
-.c12 .c18:hover > svg rect,
-.c12 .c18:focus > svg polygon,
-.c12 .c18:hover > svg polygon,
-.c12 .c18:focus > svg path,
-.c12 .c18:hover > svg path {
+.c12 .c18:focus svg rect,
+.c12 .c18:hover svg rect,
+.c12 .c18:focus svg polygon,
+.c12 .c18:hover svg polygon,
+.c12 .c18:focus svg path,
+.c12 .c18:hover svg path {
   fill: #ec0000;
 }
 
@@ -1198,6 +1202,7 @@ exports[`Header should render the tall version without a title 1`] = `
   }
 
   .c0 .c2 {
+    min-height: 50px;
     padding-right: 0;
   }
 }

--- a/packages/asc-ui/src/components/IconButton/IconButtonStyle.ts
+++ b/packages/asc-ui/src/components/IconButton/IconButtonStyle.ts
@@ -1,5 +1,5 @@
+import styled, { css } from '@datapunt/asc-core'
 import { size } from 'polished'
-import styled from '@datapunt/asc-core'
 import ButtonBaseStyle, {
   Props as ButtonBaseStyleProps,
 } from '../Button/ButtonBaseStyle'
@@ -17,10 +17,10 @@ export const IconButtonStyle = styled(ButtonBaseStyle)<Props>`
   ${({ size: sizeProp }) =>
     sizeProp
       ? size(sizeProp)
-      : `
-  width: 30px;
-  height: 30px;
-  `}
+      : css`
+          width: 30px;
+          height: 30px;
+        `}
 
   ${IconStyle} {
     ${({ iconSize }) => iconSize && size(iconSize)}

--- a/packages/asc-ui/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/packages/asc-ui/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -130,9 +130,9 @@ exports[`SearchBar should render 1`] = `
   height: 40px;
 }
 
-.c0 > .c5 > svg rect,
-.c0 > .c5 > svg polygon,
-.c0 > .c5 > svg path {
+.c0 > .c5 svg rect,
+.c0 > .c5 svg polygon,
+.c0 > .c5 svg path {
   fill: #ffffff;
 }
 

--- a/packages/asc-ui/src/components/Toggle/Toggle.test.tsx
+++ b/packages/asc-ui/src/components/Toggle/Toggle.test.tsx
@@ -3,7 +3,7 @@ import { mount, render } from 'enzyme'
 import Toggle from './Toggle'
 import 'jest-styled-components'
 import { KeyboardKeys } from '../../types'
-import ToggleHeaderButton from './ToggleHeaderButton'
+import ToggleHandlerButton from './ToggleHandlerButton'
 
 describe('Toggle', () => {
   it('should render', () => {
@@ -26,7 +26,7 @@ describe('Toggle', () => {
 
     expect(component.find('#child').exists()).toBe(false)
     component
-      .find(ToggleHeaderButton)
+      .find(ToggleHandlerButton)
       .at(0)
       .simulate('click')
     expect(component.find('#child').exists()).toBe(true)
@@ -46,7 +46,7 @@ describe('Toggle', () => {
     )
 
     component
-      .find(ToggleHeaderButton)
+      .find(ToggleHandlerButton)
       .at(0)
       .simulate('click')
     expect(component.find('#child').exists()).toBe(true)

--- a/packages/asc-ui/src/components/Toggle/Toggle.tsx
+++ b/packages/asc-ui/src/components/Toggle/Toggle.tsx
@@ -3,9 +3,9 @@ import ToggleStyle, { Props as ToggleStyleProps } from './ToggleStyle'
 import ownerDocument from '../../utils/ownerDocument'
 import usePassPropsToChildren from '../../utils/usePassPropsToChildren'
 import useActionOnEscape from '../../utils/useActionOnEscape'
-import ToggleHeaderButton from './ToggleHeaderButton'
+import ToggleHandlerButton from './ToggleHandlerButton'
 
-export type ToggleHeaderProps = {
+export type ToggleHandlerProps = {
   iconOpen?: React.ReactElement
   iconClose?: React.ReactElement
   open?: boolean
@@ -14,10 +14,10 @@ export type ToggleHeaderProps = {
 export type Props = {
   render?: boolean
   onOpen?: Function
-  ToggleHeader?: any
+  ToggleHandler?: any
   as?: keyof JSX.IntrinsicElements | React.ComponentType<any>
 } & ToggleStyleProps &
-  ToggleHeaderProps
+  ToggleHandlerProps
 
 const Toggle: React.FC<Props> = ({
   children: childrenProps,
@@ -29,7 +29,7 @@ const Toggle: React.FC<Props> = ({
   render,
   iconOpen,
   iconClose,
-  ToggleHeader,
+  ToggleHandler,
   ...otherProps
 }) => {
   const [open, setOpen] = React.useState(false)
@@ -95,7 +95,7 @@ const Toggle: React.FC<Props> = ({
       onKeyDown={handleOnKeyDown}
       {...otherProps}
     >
-      <ToggleHeader
+      <ToggleHandler
         {...{
           open,
           iconClose,
@@ -111,7 +111,7 @@ const Toggle: React.FC<Props> = ({
 
 Toggle.defaultProps = {
   render: true,
-  ToggleHeader: ToggleHeaderButton,
+  ToggleHandler: ToggleHandlerButton,
 }
 
 export default Toggle

--- a/packages/asc-ui/src/components/Toggle/ToggleHandlerButton.tsx
+++ b/packages/asc-ui/src/components/Toggle/ToggleHandlerButton.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { Close, Menu } from '@datapunt/asc-assets'
 import Icon from '../Icon'
 import ButtonToggle from '../ButtonToggle/ButtonToggleStyle'
-import { ToggleHeaderProps } from './Toggle'
+import { ToggleHandlerProps } from './Toggle'
 
-const ToggleHeaderButton: React.FC<ToggleHeaderProps> = ({
+const ToggleHandlerButton: React.FC<ToggleHandlerProps> = ({
   iconOpen,
   iconClose,
   open,
@@ -19,4 +19,4 @@ const ToggleHeaderButton: React.FC<ToggleHeaderProps> = ({
   )
 }
 
-export default ToggleHeaderButton
+export default ToggleHandlerButton

--- a/packages/asc-ui/src/components/Toggle/index.ts
+++ b/packages/asc-ui/src/components/Toggle/index.ts
@@ -1,5 +1,5 @@
 export {
   default as Toggle,
-  ToggleHeaderProps,
+  ToggleHandlerProps,
   Props as ToggleProps,
 } from './Toggle'

--- a/packages/asc-ui/src/utils/themeUtils.ts
+++ b/packages/asc-ui/src/utils/themeUtils.ts
@@ -154,7 +154,7 @@ export const svgFill = (
   if (colorType) {
     const value = color(colorType, variant)({ theme })
     if (typeof value === 'string') {
-      return `& > svg {
+      return `& svg {
         rect,
         polygon,
         path {


### PR DESCRIPTION
## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [ ] The default export from a file matches the file name
- [ ] The component styles are only placed in the `asc-core/src/components` folder. Exception is the `asc-ui/src/internals` folder where the styles are allowed. The components from this folder are just for internal use in the stories.
- [ ] The component style name follows the pattern `<ComponentName>Style/<ComponentName>Style.ts`
- [ ] Pull request has tests (we are going for 100% coverage!)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
