### PR TITLE
Also have the option to neglect the max width from the theme and have…

### DIFF
--- a/packages/asc-ui/src/components/Grid/Column.md
+++ b/packages/asc-ui/src/components/Grid/Column.md
@@ -40,6 +40,15 @@ The below example will align the child `Column` component with the remaining spa
 </Row>
 ```
 
+Also, the `Row` component can be used without a fixed width by setting the value of the prop `hasMaxwidth` to `false` (default value is `true`).
+
+```jsx
+<Row hasMaxWidth={false}>
+  ...
+</Row>
+```
+
+
 ## Debugging
 
 Setting the `debug` prop on a `<Row />` component will show both a repeating linear background images that indicated where the columns will be placed as well as as label that shows the current layout name based on the width of the screen. The `debugColor` prop can be given a valid color string (hex, hsl, rgb, rbga) which will change the color of the linear gradient.

--- a/packages/asc-ui/src/components/Grid/Grid.stories.tsx
+++ b/packages/asc-ui/src/components/Grid/Grid.stories.tsx
@@ -9,7 +9,7 @@ const ColumnStory: React.FC<{}> = () => (
   <>
     <br />
     <br />
-    <Row debug>
+    <Row debug hasMaxWidth={false}>
       <Column
         order={{ small: 2, medium: 1, big: 1, large: 1, xLarge: 1 }}
         span={{ small: 1, medium: 1, big: 1, large: 2, xLarge: 2 }}

--- a/packages/asc-ui/src/components/Grid/RowStyle.ts
+++ b/packages/asc-ui/src/components/Grid/RowStyle.ts
@@ -26,6 +26,7 @@ export type TypeProps = {
   debugColor?: string
   halign?: FlexJustify
   hasMargin?: boolean
+  hasMaxWidth?: boolean
   valign?: TypeFlexPosition
 }
 
@@ -35,7 +36,8 @@ const RowStyle = styled.div<TypeProps>`
   display: flex;
   justify-content: ${({ halign }: { halign?: string }) => halign};
   align-items: ${({ valign }: { valign?: string }) => valign};
-  max-width: ${fromTheme('maxGridWidth')}px;
+  max-width: ${({ hasMaxWidth, theme }) =>
+    hasMaxWidth ? `${fromTheme('maxGridWidth')({ theme })}px` : '100%'};
   flex-wrap: wrap;
 
   .layout-label {
@@ -142,6 +144,7 @@ const RowStyle = styled.div<TypeProps>`
 
 RowStyle.defaultProps = {
   halign: 'space-between',
+  hasMaxWidth: true,
   valign: 'stretch',
 }
 

--- a/packages/asc-ui/src/components/Grid/__tests__/Row.test.tsx
+++ b/packages/asc-ui/src/components/Grid/__tests__/Row.test.tsx
@@ -80,6 +80,28 @@ describe('RowStyle', () => {
     )
   })
 
+  it("should set the grid's max width to 100%", () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Row hasMaxWidth={false}>
+          <Column data-testid="span1" span={1}>
+            foo bar
+          </Column>
+        </Row>
+      </ThemeProvider>,
+    )
+
+    expect(container.firstChild).not.toHaveStyleRule(
+      'max-width',
+      expect.stringContaining(`${theme.maxGridWidth}`),
+    )
+
+    expect(container.firstChild).toHaveStyleRule(
+      'max-width',
+      expect.stringContaining('100%'),
+    )
+  })
+
   it('should show a linear repeating background image', () => {
     const { container } = render(
       <ThemeProvider theme={theme}>


### PR DESCRIPTION
… the grid displayed full screen

## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [ ] The default export from a file matches the file name
- [ ] The component styles are only placed in the `asc-core/src/components` folder. Exception is the `asc-ui/src/internals` folder where the styles are allowed. The components from this folder are just for internal use in the stories.
- [ ] The component style name follows the pattern `<ComponentName>Style/<ComponentName>Style.ts`
- [ ] Pull request has tests (we are going for 100% coverage!)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
