### PR TITLE
MenuFlyOut no longer opens on tab keydown, only enter or space. Fixed…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## Unreleased
+
+- Changed: `MenuFlyOut` no longer opens on tab keydown, only `enter` or `space` (besides `click` or `mouseover`)
+
 ## [0.13.0] - 2019-08-14
 
 - Changed: LinkList(LinkListItem) is renamed to List(ListItem), the Link functionality has to be done in the implementation

--- a/packages/asc-ui/src/components/Menu/MenuFlyOut/MenuFlyOut.tsx
+++ b/packages/asc-ui/src/components/Menu/MenuFlyOut/MenuFlyOut.tsx
@@ -86,7 +86,6 @@ const MenuFlyOut: React.FC<Props> = ({ children, label, ...otherProps }) => {
           // eslint-disable-next-line no-nested-ternary
           hasToggle ? flyOutOpen ? <ChevronUp /> : <ChevronDown /> : undefined
         }
-        onFocus={() => setOpen(true)}
         onClick={onHandleToggle}
         onKeyDown={onHandleKeyDown}
         aria-haspopup="true"

--- a/packages/asc-ui/src/components/Modal/Modal.tsx
+++ b/packages/asc-ui/src/components/Modal/Modal.tsx
@@ -45,6 +45,7 @@ const Modal: React.FC<Props> = ({
     return () => {
       clearTimeout(renderedTimer)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleClose = () => {


### PR DESCRIPTION
… eslint warning for missing dependency array in Modal

## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [ ] The default export from a file matches the file name
- [ ] You have been following the guidelines, written in the [README](../docs/CONTRIBUTING.md#user-content-conventions-and-rules) file
- [ ] Your code has the necessary tests written
- [ ] You have updated the [CHANGELOG.md unreleased sections](../CHANGELOG.md#muser-content-unreleased)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
