### PR TITLE
Fixed button size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ Prefix the change with one of these keywords:
 
 ## UNRELEASED
 
+- Fixed: issue with button's size
+
 ## [0.14.2-rc.1] - 2019-09-09
+
 - Fixed: issue with button's margin
 - Added: bullet-list style to List component
 - Removed: `Dataportaal` implemenation for header and frontpage blocks

--- a/packages/asc-ui/src/components/Button/Button.stories.tsx
+++ b/packages/asc-ui/src/components/Button/Button.stories.tsx
@@ -17,6 +17,7 @@ import ShareButton from './ShareButton'
 
 const ButtonBar = styled.div<{}>`
   display: flex;
+  height: 100px;
 
   & > * {
     margin-right: 5px;

--- a/packages/asc-ui/src/components/Button/ButtonStyle.ts
+++ b/packages/asc-ui/src/components/Button/ButtonStyle.ts
@@ -216,6 +216,7 @@ const ButtonStyle = styled.button<Props>`
     taskflow &&
     css`
       position: relative;
+      z-index: 0;
       && {
         margin-right: 25px;
       }

--- a/packages/asc-ui/src/components/Button/ButtonStyle.ts
+++ b/packages/asc-ui/src/components/Button/ButtonStyle.ts
@@ -20,10 +20,10 @@ const defaultProps = {
 export const ArrowRight = styled.div`
   position: absolute;
   top: 0;
-  right: -38px;
+  right: -37px;
   width: 0;
   height: 0;
-  border: 23px solid rgba(255, 255, 255, 0);
+  border: 22px solid rgba(255, 255, 255, 0);
   border-left: 15px solid ${themeColor('secondary')};
   ${transitions('border-color', '0.1s ease-in-out')}
   :after {
@@ -189,6 +189,7 @@ export const IconRight = styled(Icon)`
 `
 
 const ButtonStyle = styled.button<Props>`
+  height: 44px;
   white-space: nowrap;
   display: inline-flex;
   align-items: center;

--- a/packages/asc-ui/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/asc-ui/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Button should render the button 1`] = `
 .c0 {
+  height: 44px;
   white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/packages/asc-ui/src/components/DocumentCover/__snapshots__/DocumentCover.test.tsx.snap
+++ b/packages/asc-ui/src/components/DocumentCover/__snapshots__/DocumentCover.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`DocumentCover should render 1`] = `
 }
 
 .c5 {
+  height: 44px;
   white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/packages/asc-ui/src/components/deprecated/IconButton/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/asc-ui/src/components/deprecated/IconButton/__snapshots__/IconButton.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`IconButton should render the IconButton 1`] = `
         "isStatic": false,
         "rules": Array [
           "
+  height: 44px;
   white-space: nowrap;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Fixed button size

1. Height of all buttons is 46px instead of 44px (See design system: 

> De hoogte van knoppen is altijd 44 px.
![image](https://user-images.githubusercontent.com/7781865/64625616-cad1cb00-d3ec-11e9-97e7-eb4163763244.png)

2. If buttons parent container height has a fixed height (eg: 100px) then the buttons height is automatically increasing its size:
![image](https://user-images.githubusercontent.com/7781865/64625765-040a3b00-d3ed-11e9-89d9-eac6fd66c936.png)

3. Set `z-index: 0` to fix bug on `:focus`
![image](https://user-images.githubusercontent.com/7781865/64626386-0f119b00-d3ee-11e9-9cce-6359761e6aa4.png)

