### PR TITLE
Add flex item alignment

### DIFF
--- a/packages/asc-ui/src/components/Link/LinkStyle.ts
+++ b/packages/asc-ui/src/components/Link/LinkStyle.ts
@@ -40,6 +40,7 @@ export const InlineLinkStyleCSS = css`
 `
 export const DefaultLinkStyleCSS = css<Props>`
   display: inline-flex;
+  align-items: center;
   text-decoration: none;
   font-weight: 700;
   color: ${({ color: colorOverride, theme }) =>


### PR DESCRIPTION
This will align the Chevron correctly with the text.
