### PR TITLE
Added storybook support for ie11

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -8,12 +8,18 @@ const styledComponentsTransformer = createTransformer({ displayName: true })
 const basePath = path.resolve(__dirname, '../', 'packages')
 
 module.exports = ({ config, mode }) => {
-  const isDev = (mode === 'DEVELOPMENT')
+  const isDev = mode === 'DEVELOPMENT'
 
   // Add typescript support
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
     use: [
+      {
+        loader: 'babel-loader',
+        options: {
+          presets: ['@babel/preset-env'],
+        },
+      },
       {
         loader: require.resolve('awesome-typescript-loader'),
         options: {
@@ -25,9 +31,7 @@ module.exports = ({ config, mode }) => {
           getCustomTransformers: () => ({
             before: [styledComponentsTransformer],
           }),
-          reportFiles: [
-            "packages/**/*.{ts,tsx}"
-          ],
+          reportFiles: ['packages/**/*.{ts,tsx}'],
         },
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## Unreleased
+
+- Fixed: IE11 support, by adding `babel-loader` to webpack config
+
 ## Canary
 
 - Added: FilterTag component.


### PR DESCRIPTION
# Problem: Somehow there is no IE11 support.

Try to open [amsterdam-styled-components](https://amsterdam.github.io/amsterdam-styled-components/?path=/story/atoms-typography-blockquote--default-style) in IE11 and you get this:

<img width="1680" alt="ie11 1" src="https://user-images.githubusercontent.com/7781865/70053542-ef95a300-15d5-11ea-978c-27394e8fa066.png">

I added `babel-loader` to webpack and it solves the problem.

Now it looks normal:
<img width="1680" alt="ie11 2" src="https://user-images.githubusercontent.com/7781865/70053543-ef95a300-15d5-11ea-8df6-743860da9fe4.png">

_The other changes are by Netlify..._