### PR TITLE
(chore) Remove hardcoded input attributes

### DIFF
--- a/packages/asc-ui/src/components/Input/InputStyle.ts
+++ b/packages/asc-ui/src/components/Input/InputStyle.ts
@@ -5,13 +5,7 @@ type StyleProps = {
   error?: string | boolean
 }
 
-const InputStyle = styled.input.attrs({
-  type: 'text',
-  autoCapitalize: 'off',
-  autoComplete: 'off',
-  autoCorrect: 'off',
-  spellCheck: false,
-})<StyleProps>`
+const InputStyle = styled.input<StyleProps>`
   appearance: none;
   font-size: 1rem;
   border: solid 1px ${themeColor('tint', 'level5')};

--- a/packages/asc-ui/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/asc-ui/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -26,13 +26,8 @@ exports[`Input component structure should render 1`] = `
 }
 
 <input
-  autocapitalize="off"
-  autocomplete="off"
-  autocorrect="off"
   class="c0"
   id="id"
-  spellcheck="false"
-  type="text"
   value="test-value"
 />
 `;


### PR DESCRIPTION
This PR removes attributes that were hardcoded on the `Input` component. These attributes prevented setting the `type` attribute of the HTMLElement, for instance.