### PR TITLE
Changed: Input has error state; FormLabel updated style;  FormLabel got error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ Prefix the change with one of these keywords:
 
 ## Unreleased
 
+- Changed: TextField got new `FormLabel` with `errorMessage`
+- Changed: FormLabel has updated style (to design system)
+- Changed: Input has `error` variant
 - Added: RadioGroup component.
-- Updated: Radio component. (completely redeveloped)
-- Updated: FilterBox component (removed show more button + sublabel)
+- Changed: Radio component. (completely redeveloped)
+- Changed: FilterBox component (removed show more button + sublabel)
 - Fixed: IE11 support, by adding `babel-loader` to webpack config
 
 ## Canary

--- a/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
+++ b/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
@@ -4,7 +4,7 @@ import { srOnlyStyle, getTypographyFromTheme } from '../../utils'
 interface IProps {
   htmlFor?: string
   srOnly: boolean
-  error?: string
+  error?: string | boolean
 }
 
 const FormLabelStyle = styled.label.attrs<IProps>(({ htmlFor }: IProps) => {

--- a/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
+++ b/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
@@ -4,6 +4,7 @@ import { srOnlyStyle, getTypographyFromTheme, themeSpacing } from '../../utils'
 interface IProps {
   htmlFor?: string
   srOnly: boolean
+  label?: string
   error?: string | boolean
 }
 
@@ -12,8 +13,9 @@ const FormLabelStyle = styled.label.attrs<IProps>(({ htmlFor }: IProps) => {
     htmlFor,
   }
 })<IProps>`
-  ${({ srOnly }) =>
-    !srOnly &&
+  ${({ srOnly, label, error }) =>
+    (label || error) && // Style if `label` or `errer` prop is set
+    !srOnly && // Don't style for screen reader
     css`
       ${({ theme }) =>
         getTypographyFromTheme()({

--- a/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
+++ b/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
@@ -1,5 +1,5 @@
 import styled, { css } from '@datapunt/asc-core'
-import { srOnlyStyle, getTypographyFromTheme } from '../../utils'
+import { srOnlyStyle, getTypographyFromTheme, themeSpacing } from '../../utils'
 
 interface IProps {
   htmlFor?: string
@@ -22,7 +22,7 @@ const FormLabelStyle = styled.label.attrs<IProps>(({ htmlFor }: IProps) => {
           theme,
         })};
       display: block;
-      padding-bottom: 10px;
+      padding-bottom: ${themeSpacing(2)};
       font-weight: 700;
     `}
 

--- a/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
+++ b/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
@@ -1,17 +1,31 @@
-import styled from '@datapunt/asc-core'
+import styled, { css } from '@datapunt/asc-core'
 import { srOnlyStyle } from '../../utils'
 
 interface IProps {
   htmlFor?: string
   srOnly: boolean
+  error?: string
 }
 
 const FormLabelStyle = styled.label.attrs<IProps>(({ htmlFor }: IProps) => {
   return {
-    type: 'text',
     htmlFor,
   }
-})`
+})<IProps>`
+  ${({ srOnly }) =>
+    !srOnly &&
+    css`
+      display: block;
+      padding-bottom: 10px;
+      font-weight: 700;
+    `}
+
+  ${({ error }) =>
+    error &&
+    css`
+      color: red;
+    `}  
+
   ${srOnlyStyle()}
 `
 

--- a/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
+++ b/packages/asc-ui/src/components/FormLabelStyle/FormLabelStyle.ts
@@ -1,5 +1,5 @@
 import styled, { css } from '@datapunt/asc-core'
-import { srOnlyStyle } from '../../utils'
+import { srOnlyStyle, getTypographyFromTheme } from '../../utils'
 
 interface IProps {
   htmlFor?: string
@@ -15,6 +15,12 @@ const FormLabelStyle = styled.label.attrs<IProps>(({ htmlFor }: IProps) => {
   ${({ srOnly }) =>
     !srOnly &&
     css`
+      ${({ theme }) =>
+        getTypographyFromTheme()({
+          as: 'p',
+          gutterBottom: 0,
+          theme,
+        })};
       display: block;
       padding-bottom: 10px;
       font-weight: 700;

--- a/packages/asc-ui/src/components/Input/Input.tsx
+++ b/packages/asc-ui/src/components/Input/Input.tsx
@@ -20,6 +20,7 @@ export interface InputProps extends InputMethods {
   keepFocus?: boolean
   blurOnEscape?: boolean
   focusOnRender?: boolean
+  error?: string
 }
 
 export interface Shared {}
@@ -28,6 +29,7 @@ const Input: React.FC<InputProps> = ({
   blurOnEscape,
   focusOnRender,
   value,
+  error,
   ...props
 }: InputProps) => {
   const ref = React.useRef<HTMLInputElement>(null)
@@ -70,6 +72,7 @@ const Input: React.FC<InputProps> = ({
             onKeyDown={e => {
               handleOnKeyDown(e, context)
             }}
+            error={error}
             value={value}
           />
         )

--- a/packages/asc-ui/src/components/Input/InputStyle.ts
+++ b/packages/asc-ui/src/components/Input/InputStyle.ts
@@ -1,5 +1,9 @@
-import styled from '@datapunt/asc-core'
+import styled, { css } from '@datapunt/asc-core'
 import { themeColor, focusStyleOutline } from '../../utils'
+
+type StyleProps = {
+  error?: string | boolean
+}
 
 const InputStyle = styled.input.attrs({
   type: 'text',
@@ -7,7 +11,7 @@ const InputStyle = styled.input.attrs({
   autoComplete: 'off',
   autoCorrect: 'off',
   spellCheck: false,
-})`
+})<StyleProps>`
   appearance: none;
   font-size: 1rem;
   border: solid 1px ${themeColor('tint', 'level5')};
@@ -17,10 +21,19 @@ const InputStyle = styled.input.attrs({
   padding: 10px;
   width: 100%;
   ${focusStyleOutline(2, 0.5)}
+  ${({ error }) =>
+    !error &&
+    css`
+      &:hover {
+        border-color: ${themeColor('tint', 'level6')};
+      }
+    `}
 
-  &:hover {
-    border-color: ${themeColor('tint', 'level6')};
-  }
+  ${({ error }) =>
+    error &&
+    css`
+      border-color: ${themeColor('secondary', 'main')};
+    `}
 `
 
 export default InputStyle

--- a/packages/asc-ui/src/components/TextField/TextField.stories.tsx
+++ b/packages/asc-ui/src/components/TextField/TextField.stories.tsx
@@ -4,14 +4,16 @@ import { action } from '@storybook/addon-actions'
 import TextField from './TextField'
 
 const props = {
-  label: 'text field description',
+  label: 'Text field label',
   onBlur: action('onBlur'),
   onFocus: action('onFocus'),
   onKeyDown: action('onKeyDown'),
   value: '',
 }
 
-const TextFieldComponent: React.FC<{}> = () => {
+const TextFieldComponent: React.FC<{ errorMessage?: string }> = ({
+  errorMessage,
+}) => {
   const [text, setText] = React.useState('')
 
   return (
@@ -19,6 +21,7 @@ const TextFieldComponent: React.FC<{}> = () => {
       {...props}
       value={text}
       id="text-filed-id"
+      errorMessage={errorMessage}
       onChange={e => setText(e.target.value)}
       onClear={() => setText('')}
     />
@@ -45,6 +48,9 @@ storiesOf('Atoms/TextField', module)
     <div style={{ padding: '40px 10px' }}>{storyFn()}</div>
   ))
   .add('default state with label', () => <TextFieldComponent />)
+  .add('default state with label and error', () => (
+    <TextFieldComponent errorMessage="Error message" />
+  ))
   .add('default state with accesible label for screen reader', () => (
     <TextFieldSrOnlyComponent />
   ))

--- a/packages/asc-ui/src/components/TextField/TextField.stories.tsx
+++ b/packages/asc-ui/src/components/TextField/TextField.stories.tsx
@@ -4,16 +4,16 @@ import { action } from '@storybook/addon-actions'
 import TextField from './TextField'
 
 const props = {
-  label: 'Text field label',
   onBlur: action('onBlur'),
   onFocus: action('onFocus'),
   onKeyDown: action('onKeyDown'),
   value: '',
 }
 
-const TextFieldComponent: React.FC<{ errorMessage?: string }> = ({
-  errorMessage,
-}) => {
+const TextFieldComponent: React.FC<{
+  label?: string
+  errorMessage?: string
+}> = ({ label, errorMessage }) => {
   const [text, setText] = React.useState('')
 
   return (
@@ -21,6 +21,7 @@ const TextFieldComponent: React.FC<{ errorMessage?: string }> = ({
       {...props}
       value={text}
       id="text-filed-id"
+      label={label}
       errorMessage={errorMessage}
       onChange={e => setText(e.target.value)}
       onClear={() => setText('')}
@@ -47,9 +48,24 @@ storiesOf('Atoms/TextField', module)
   .addDecorator(storyFn => (
     <div style={{ padding: '40px 10px' }}>{storyFn()}</div>
   ))
-  .add('default state with label', () => <TextFieldComponent />)
+  .add('default state', () => (
+    <>
+      <TextFieldComponent label="Text field label" />
+      <p>
+        Without label:
+        <TextFieldComponent />
+      </p>
+    </>
+  ))
   .add('default state with label and error', () => (
-    <TextFieldComponent errorMessage="Error message" />
+    <>
+      <TextFieldComponent
+        label="Text field label"
+        errorMessage="Error message"
+      />
+      <br />
+      <TextFieldComponent errorMessage="Error message only" />
+    </>
   ))
   .add('default state with accesible label for screen reader', () => (
     <TextFieldSrOnlyComponent />

--- a/packages/asc-ui/src/components/TextField/TextField.tsx
+++ b/packages/asc-ui/src/components/TextField/TextField.tsx
@@ -11,6 +11,7 @@ export interface TextFieldProps extends InputProps {
   label?: string
   keepFocus?: boolean
   srOnly: boolean
+  errorMessage?: string
   onClear?: Function
 }
 
@@ -22,33 +23,42 @@ const TextField = ({
   keepFocus,
   blurOnEscape,
   focusOnRender,
+  errorMessage,
   ...otherProps
 }: TextFieldProps) => {
   const uid = useUID()
   return (
-    <TextFieldStyle>
+    <>
       <FormLabelStyle htmlFor={uid} srOnly={srOnly}>
         {label}
       </FormLabelStyle>
-      <Input
-        {...{ keepFocus, value, blurOnEscape, focusOnRender }}
-        {...otherProps}
-        id={uid}
-      />
-      {onClear && value && (
-        <Button
-          size={30}
-          variant="blank"
-          type="button"
-          aria-label="Close"
-          onClick={() => onClear()}
-        >
-          <Icon>
-            <Close />
-          </Icon>
-        </Button>
+      {errorMessage && (
+        <FormLabelStyle htmlFor={uid} srOnly={srOnly} error={errorMessage}>
+          {errorMessage}
+        </FormLabelStyle>
       )}
-    </TextFieldStyle>
+      <TextFieldStyle>
+        <Input
+          {...{ keepFocus, value, blurOnEscape, focusOnRender }}
+          {...otherProps}
+          id={uid}
+          error={errorMessage}
+        />
+        {onClear && value && (
+          <Button
+            size={30}
+            variant="blank"
+            type="button"
+            aria-label="Close"
+            onClick={() => onClear()}
+          >
+            <Icon>
+              <Close />
+            </Icon>
+          </Button>
+        )}
+      </TextFieldStyle>
+    </>
   )
 }
 

--- a/packages/asc-ui/src/components/TextField/TextField.tsx
+++ b/packages/asc-ui/src/components/TextField/TextField.tsx
@@ -12,6 +12,8 @@ export interface TextFieldProps extends InputProps {
   keepFocus?: boolean
   srOnly: boolean
   errorMessage?: string
+  labelStyle?: object
+  errorStyle?: object
   onClear?: Function
 }
 
@@ -24,16 +26,28 @@ const TextField = ({
   blurOnEscape,
   focusOnRender,
   errorMessage,
+  labelStyle,
+  errorStyle,
   ...otherProps
 }: TextFieldProps) => {
   const uid = useUID()
   return (
     <>
-      <FormLabelStyle htmlFor={uid} srOnly={srOnly}>
+      <FormLabelStyle
+        htmlFor={uid}
+        srOnly={srOnly}
+        label={label}
+        style={labelStyle}
+      >
         {label}
       </FormLabelStyle>
       {errorMessage && (
-        <FormLabelStyle htmlFor={uid} srOnly={srOnly} error={errorMessage}>
+        <FormLabelStyle
+          htmlFor={uid}
+          srOnly={srOnly}
+          error={errorMessage}
+          style={errorStyle}
+        >
           {errorMessage}
         </FormLabelStyle>
       )}


### PR DESCRIPTION
- Changed: TextField got new `FormLabel` with `errorMessage`
- Changed: FormLabel has updated style (to design system)
- Changed: Input has `error` variant

Check these Storybook pages:
- https://5df1fcaf6e23b20009cc5b75--amsterdam-styled-components.netlify.com/?path=/story/atoms-textfield--default-state
- https://5df1fcaf6e23b20009cc5b75--amsterdam-styled-components.netlify.com/?path=/story/atoms-textfield--default-state-with-label-and-error