### PR TITLE
Fixed: click outside modal box didn't close the modal, added: "open" prop to MenuToggle to also control the open-state outside of the component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Prefix the change with one of these keywords:
 ## Unreleased
 
 - Changed: Removed `background-color` style for List comp
+- Fixed: click outside modal box didn't close the modal
+- Added: "open" prop to MenuToggle to also control the open-state outside of the component
 
 ## Canary
 

--- a/packages/asc-ui/src/components/Menu/MenuToggle/MenuToggle.tsx
+++ b/packages/asc-ui/src/components/Menu/MenuToggle/MenuToggle.tsx
@@ -3,33 +3,25 @@ import MenuList from '../MenuList/MenuList'
 import MenuContext from '../MenuContext'
 import MenuToggleStyle, { Props } from './MenuToggleStyle'
 import Toggle from '../../Toggle/Toggle'
+import useOptionalControlledState from '../../../utils/hooks/useOptionalControlledState'
 
 const MenuToggle: React.FC<Props> = ({
   children,
   onExpand,
   align = 'left',
+  open,
   ...otherProps
 }) => {
-  const [menuOpen, setMenuOpen] = React.useState(false)
+  const [menuOpen, setMenuOpen] = useOptionalControlledState(open, onExpand)
   const toggleMenu = () => {
     setMenuOpen(!menuOpen)
   }
 
-  const onOpen = (open: boolean) => {
-    if (!open) {
+  const onOpen = (isOpen: boolean) => {
+    if (!isOpen) {
       setMenuOpen(false)
     }
   }
-
-  const handleOnExpand = React.useCallback(
-    open => onExpand && onExpand(open),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  )
-
-  React.useEffect(() => {
-    handleOnExpand(menuOpen)
-  }, [handleOnExpand, menuOpen])
 
   return (
     <MenuContext.Provider
@@ -57,6 +49,7 @@ const MenuToggle: React.FC<Props> = ({
 
 MenuToggle.defaultProps = {
   align: 'left',
+  open: false,
 }
 
 export default MenuToggle

--- a/packages/asc-ui/src/components/Menu/MenuToggle/MenuToggleStyle.ts
+++ b/packages/asc-ui/src/components/Menu/MenuToggle/MenuToggleStyle.ts
@@ -16,6 +16,7 @@ import ToggleButtonStyle from '../../Button/ToggleButton'
 export type Props = {
   align?: 'left' | 'right'
   onExpand?: Function
+  open?: boolean
   hasBackDrop?: boolean
 } & ShowHideTypes
 

--- a/packages/asc-ui/src/components/Modal/ModalStyle.ts
+++ b/packages/asc-ui/src/components/Modal/ModalStyle.ts
@@ -17,6 +17,7 @@ const ModalStyle = styled.div<Props>`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  pointer-events: all;
 
   ${TopBarStyle} {
     min-height: 54px;
@@ -30,7 +31,7 @@ export const ModalStyleContainer = styled.div`
   height: 100vh;
   margin: 0;
   place-items: center center;
-  pointer-events: all;
+  pointer-events: none;
 `
 
 export default ModalStyle

--- a/packages/asc-ui/src/utils/hooks/useOptionalControlledState.test.tsx
+++ b/packages/asc-ui/src/utils/hooks/useOptionalControlledState.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { getByText, render } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react-hooks'
+import useOptionalControlledState from './useOptionalControlledState'
+
+describe('useOptionalControlledState', () => {
+  const mockFn: jest.Mock = jest.fn()
+  const ref: React.Ref<HTMLButtonElement> = React.createRef()
+
+  beforeEach(() => {
+    render(
+      <button type="button" ref={ref} data-testid="element" onFocus={mockFn} />,
+    )
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  function getHookResult(
+    controlledBoolean?: boolean,
+    setControlledBoolean?: Function,
+    options?: object,
+  ) {
+    const { result } = renderHook(() => {
+      const [value, setFn] = useOptionalControlledState(
+        controlledBoolean,
+        setControlledBoolean,
+      )
+      return { value, setFn }
+    }, options)
+
+    return result
+  }
+
+  const mockedControlledSetBooleanFn = jest.fn()
+
+  it('should call the controlledSetBoolean when setFn changes', () => {
+    const result = getHookResult(false, mockedControlledSetBooleanFn)
+    expect(result.current.value).toBe(false)
+
+    act(() => {
+      result.current.setFn(true)
+    })
+
+    expect(mockedControlledSetBooleanFn).toHaveBeenCalledWith(true)
+    expect(result.current.value).toBe(true)
+  })
+
+  it('should set the boolean when a controlled boolean is passed', () => {
+    const result = getHookResult(true, mockedControlledSetBooleanFn)
+    expect(result.current.value).toBe(true)
+
+    act(() => {
+      result.current.setFn(false)
+    })
+
+    expect(mockedControlledSetBooleanFn).toHaveBeenCalledWith(false)
+    expect(result.current.value).toBe(false)
+  })
+
+  it('should work like useState when no controlled value is given to the hook', () => {
+    const { result } = renderHook(() => {
+      const [value, setFn] = useOptionalControlledState()
+      return { value, setFn }
+    })
+    expect(result.current.value).toBe(false)
+
+    act(() => {
+      result.current.setFn(true)
+    })
+
+    expect(result.current.value).toBe(true)
+
+    act(() => {
+      result.current.setFn(false)
+    })
+
+    expect(result.current.value).toBe(false)
+  })
+
+  it('should set the state when the controlled value is changed', () => {
+    const Wrapper: React.FC<any> = ({ open }) => {
+      const [value] = useOptionalControlledState(open, () => {})
+      return <div data-testid="node">{value ? 'open' : ''}</div>
+    }
+    const { container, rerender } = render(<Wrapper open={false} />)
+    rerender(<Wrapper open />)
+
+    expect(getByText(container, 'open')).toBeDefined()
+  })
+})

--- a/packages/asc-ui/src/utils/hooks/useOptionalControlledState.ts
+++ b/packages/asc-ui/src/utils/hooks/useOptionalControlledState.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Sometimes we want the user to control and watch the open / active state of a component
+
+ * @param [controlledBoolean] The boolean to set the (initial) state
+ * @param [onSetBoolean] Function This will be called as soon as the state is changed
+ */
+const useOptionalControlledState = (
+  controlledBoolean?: boolean,
+  onSetBoolean?: Function,
+) => {
+  const [boolean, setBoolean] = useState(controlledBoolean || false)
+
+  useEffect(() => {
+    if (typeof controlledBoolean !== 'undefined') {
+      setBoolean(controlledBoolean)
+    }
+  }, [controlledBoolean])
+
+  useEffect(() => {
+    if (onSetBoolean) {
+      onSetBoolean(boolean)
+    }
+  }, [boolean])
+
+  return [boolean, setBoolean] as const
+}
+
+export default useOptionalControlledState

--- a/packages/asc-ui/src/utils/hooks/useOptionalControlledState.ts
+++ b/packages/asc-ui/src/utils/hooks/useOptionalControlledState.ts
@@ -16,13 +16,13 @@ const useOptionalControlledState = (
     if (typeof controlledBoolean !== 'undefined') {
       setBoolean(controlledBoolean)
     }
-  }, [controlledBoolean])
+  }, [controlledBoolean, setBoolean])
 
   useEffect(() => {
     if (onSetBoolean) {
       onSetBoolean(boolean)
     }
-  }, [boolean])
+  }, [boolean, onSetBoolean])
 
   return [boolean, setBoolean] as const
 }


### PR DESCRIPTION
## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [ ] The default export from a file matches the file name
- [ ] You have been following the guidelines, written in the [README](../blob/master/docs/CONTRIBUTING.md#user-content-conventions-and-rules) file
- [ ] Your code has the necessary tests written
- [ ] You have updated the [CHANGELOG.md unreleased sections](../blob/master/CHANGELOG.md#muser-content-unreleased)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
