### PR TITLE
Add CompactPager component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Prefix the change with one of these keywords:
 - Changed: Removed `background-color` style for List comp
 - Fixed: click outside modal box didn't close the modal
 - Added: "open" prop to MenuToggle to also control the open-state outside of the component
+- Added: CompactPager component
 
 ## Canary
 

--- a/packages/asc-ui/src/components/CompactPager/CompactPager.stories.tsx
+++ b/packages/asc-ui/src/components/CompactPager/CompactPager.stories.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import CompactPager from './CompactPager'
+
+storiesOf('Composed/CompactPager', module)
+  .addDecorator(storyFn => (
+    <div
+      style={{
+        display: 'flex',
+        maxWidth: 400,
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        padding: '40px 10px',
+      }}
+    >
+      {storyFn()}
+    </div>
+  ))
+  .add('variants', () => {
+    const [currentPage, setCurrentPage] = useState(1)
+
+    return (
+      <CompactPager
+        page={currentPage}
+        pageSize={20}
+        collectionSize={60}
+        onPageChange={page => setCurrentPage(page)}
+      />
+    )
+  })

--- a/packages/asc-ui/src/components/CompactPager/CompactPager.test.tsx
+++ b/packages/asc-ui/src/components/CompactPager/CompactPager.test.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { ThemeProvider, ascDefaultTheme } from '@datapunt/asc-core'
+import CompactPager, { determineTotalPages } from './CompactPager'
+import { PREV_BUTTON, NEXT_BUTTON } from './test-ids'
+
+describe('CompactPager', () => {
+  const MockComponent = (props: any) => (
+    <ThemeProvider theme={ascDefaultTheme}>
+      <CompactPager page={1} pageSize={20} collectionSize={60} {...props} />
+    </ThemeProvider>
+  )
+
+  it('should change the page when pressing prev button', () => {
+    const onPageChangeMock = jest.fn()
+    const { getByTestId } = render(
+      <MockComponent page={2} onPageChange={onPageChangeMock} />,
+    )
+
+    fireEvent.click(getByTestId(PREV_BUTTON))
+    expect(onPageChangeMock).toHaveBeenCalledWith(1)
+  })
+
+  it('should not change the page at the bounds when pressing the prev button', () => {
+    const onPageChangeMock = jest.fn()
+    const { getByTestId } = render(
+      <MockComponent page={1} onPageChange={onPageChangeMock} />,
+    )
+
+    fireEvent.click(getByTestId(PREV_BUTTON))
+    expect(onPageChangeMock).not.toHaveBeenCalled()
+  })
+
+  it('should change the page when pressing next button', () => {
+    const onPageChangeMock = jest.fn()
+    const { getByTestId } = render(
+      <MockComponent page={1} onPageChange={onPageChangeMock} />,
+    )
+
+    fireEvent.click(getByTestId(NEXT_BUTTON))
+    expect(onPageChangeMock).toHaveBeenCalledWith(2)
+  })
+
+  it('should not change the page at the bounds when pressing the next button', () => {
+    const onPageChangeMock = jest.fn()
+    const { getByTestId } = render(
+      <MockComponent page={3} onPageChange={onPageChangeMock} />,
+    )
+
+    fireEvent.click(getByTestId(NEXT_BUTTON))
+    expect(onPageChangeMock).not.toHaveBeenCalled()
+  })
+
+  describe('determineTotalPages', () => {
+    it('should determine the amount of pages', () => {
+      const PAGE_SIZE = 20
+      const overBound = determineTotalPages(63, PAGE_SIZE)
+      const underBound = determineTotalPages(58, PAGE_SIZE)
+      const exactBound = determineTotalPages(60, PAGE_SIZE)
+      const noCollection = determineTotalPages(0, PAGE_SIZE)
+      const negativeCollection = determineTotalPages(-10, PAGE_SIZE)
+      const noPageSize = determineTotalPages(60, 0)
+      const negativePageSize = determineTotalPages(60, -10)
+
+      expect(overBound).toEqual(4)
+      expect(underBound).toEqual(3)
+      expect(exactBound).toEqual(3)
+      expect(noCollection).toEqual(1)
+      expect(negativeCollection).toEqual(1)
+      expect(noPageSize).toEqual(1)
+      expect(negativePageSize).toEqual(1)
+    })
+  })
+})

--- a/packages/asc-ui/src/components/CompactPager/CompactPager.tsx
+++ b/packages/asc-ui/src/components/CompactPager/CompactPager.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { ChevronRight, ChevronLeft } from '@datapunt/asc-assets'
+import CompactPagerStyle, { PagerText, PagerButton } from './CompactPagerStyle'
+import { PREV_BUTTON, NEXT_BUTTON } from './test-ids'
+
+function clampNumber(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function determineTotalPages(collectionSize: number, pageSize: number) {
+  if (collectionSize < 1 || pageSize < 1) {
+    return 1
+  }
+
+  return Math.ceil(collectionSize / pageSize)
+}
+
+export interface Props {
+  /**
+   * The current page number. Page numbers start with `1`.
+   */
+  page: number
+  /**
+   * The number of items per page.
+   */
+  pageSize: number
+  /**
+   * The number of items in your paginated collection.
+   *
+   * Note that this is not the same as the number of pages, but will be used to calculate it instead.
+   */
+  collectionSize: number
+  /**
+   * Callback triggered when interaction with the pager changes the page number.
+   */
+  onPageChange?: (page: number) => void
+}
+
+const CompactPager: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
+  page,
+  pageSize,
+  collectionSize,
+  onPageChange,
+  ...otherProps
+}) => {
+  const totalPages = determineTotalPages(collectionSize, pageSize)
+  const hasPrevPage = page > 1
+  const hasNextPage = page < totalPages
+
+  function movePageCursor(difference: number) {
+    if (onPageChange === undefined) {
+      return
+    }
+
+    const newPage = clampNumber(page + difference, 0, totalPages)
+
+    if (newPage !== page) {
+      onPageChange(newPage)
+    }
+  }
+
+  return (
+    <CompactPagerStyle {...otherProps}>
+      <PagerButton
+        size={44}
+        variant="blank"
+        icon={<ChevronLeft />}
+        disabled={!hasPrevPage}
+        aria-label="Vorige pagina"
+        onClick={() => movePageCursor(-1)}
+        data-testid={PREV_BUTTON}
+      />
+      <PagerText
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label={`Pagina ${page} van ${totalPages}`}
+      >
+        <strong>{page}</strong> van {totalPages}
+      </PagerText>
+      <PagerButton
+        size={44}
+        variant="blank"
+        icon={<ChevronRight />}
+        disabled={!hasNextPage}
+        aria-label="Volgende pagina"
+        onClick={() => movePageCursor(1)}
+        data-testid={NEXT_BUTTON}
+      />
+    </CompactPagerStyle>
+  )
+}
+
+export default CompactPager

--- a/packages/asc-ui/src/components/CompactPager/CompactPagerStyle.ts
+++ b/packages/asc-ui/src/components/CompactPager/CompactPagerStyle.ts
@@ -1,0 +1,24 @@
+import styled from '@datapunt/asc-core'
+import Button from '../Button'
+import { themeColor, themeSpacing } from '../../utils'
+
+export default styled.div`
+  display: flex;
+  align-items: center;
+  border: 1px solid ${themeColor('tint', 'level3')};
+`
+
+export const PagerButton = styled(Button)`
+  &:first-of-type {
+    border-right: 1px solid ${themeColor('tint', 'level3')};
+  }
+
+  &:last-of-type {
+    border-left: 1px solid ${themeColor('tint', 'level3')};
+  }
+`
+
+export const PagerText = styled.span`
+  padding: 0 ${themeSpacing(2)};
+  margin: 0 auto;
+`

--- a/packages/asc-ui/src/components/CompactPager/index.ts
+++ b/packages/asc-ui/src/components/CompactPager/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CompactPager'

--- a/packages/asc-ui/src/components/CompactPager/test-ids.ts
+++ b/packages/asc-ui/src/components/CompactPager/test-ids.ts
@@ -1,0 +1,2 @@
+export const PREV_BUTTON = 'prevbutton'
+export const NEXT_BUTTON = 'nextbutton'

--- a/packages/asc-ui/src/index.ts
+++ b/packages/asc-ui/src/index.ts
@@ -96,6 +96,7 @@ import Footer, {
   FooterTop,
   FooterStyles,
 } from './components/Footer'
+import CompactPager from './components/CompactPager'
 import ViewerContainer from './components/ViewerContainer/ViewerContainer'
 import { themeColor } from './utils'
 
@@ -235,4 +236,5 @@ export {
   DocumentCover,
   Tag,
   ViewerContainer,
+  CompactPager,
 }


### PR DESCRIPTION
This PR adds a new CompactPager component which allows the user to create a pager for a collection of a set number of items and divide them into a specified number of pages.

![image](https://user-images.githubusercontent.com/695720/72421920-b7ab7f00-3781-11ea-9def-e9c172f0f34a.png)
