### PR TITLE
Removed: `text-decoration` hover styling from the `HeaderTitle` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Prefix the change with one of these keywords:
 
 ## Unreleased
 
+- Removed: `text-decoration` hover styling from the `HeaderTitle` component (according to design system)
 - Added: indeterminate state to Checkboxes
 - Changed: **BREAKING** package `styled-components` is now a peer-dependency in `asc-core`! Include the package `styled-components` in your project.
 - Changed: The `TextField` component does now have an associated label

--- a/packages/asc-ui/src/components/Header/HeaderTitleStyle.ts
+++ b/packages/asc-ui/src/components/Header/HeaderTitleStyle.ts
@@ -10,6 +10,7 @@ const HeaderTitleStyle = styled(Link)`
 
   &:hover {
     color: inherit;
+    text-decoration: none;
   }
 
   @media screen and ${breakpoint('max-width', 'mobileM')} {

--- a/packages/asc-ui/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/packages/asc-ui/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -109,6 +109,8 @@ exports[`Header should render the short version 1`] = `
 
 .c10:hover {
   color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c12 {
@@ -416,6 +418,8 @@ exports[`Header should render the short version without the full width 1`] = `
 
 .c10:hover {
   color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c12 {
@@ -723,6 +727,8 @@ exports[`Header should render the tall version 1`] = `
 
 .c13:hover {
   color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c15 {
@@ -1135,6 +1141,8 @@ exports[`Header should render the tall version with a custom logo 1`] = `
 
 .c11:hover {
   color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c13 {
@@ -1778,6 +1786,8 @@ exports[`Header should render the tall version without logo 1`] = `
 
 .c9:hover {
   color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c11 {


### PR DESCRIPTION
see issue #330