### PR TITLE
Handle large text overflow in Select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ Prefix the change with one of these keywords:
 ## Unreleased
 
 - Changed: updated the styling of `Alert` conform to design system
+- Changed: Select can now handle large texts by overflowing into an ellipsis
 - Changed: **BREAKING** removed the `compact` prop/variant in `Alert`
 - Changed: **BREAKING** `svgFill` now only accepts CSS color literal or a `ThemeFn` which returns a CSS color (see: https://github.com/Amsterdam/amsterdam-styled-components/pull/594).
+- Changed: **BREAKING** elements using `aria-hidden` are no longer set to `display: none`
 
 ## [0.20.0]
 

--- a/packages/asc-ui/src/components/GlobalStyle/GlobalStyle.ts
+++ b/packages/asc-ui/src/components/GlobalStyle/GlobalStyle.ts
@@ -14,10 +14,6 @@ const GlobalStyle = createGlobalStyle`
   article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
       display: block;
   }
-
-  [aria-hidden="true"] {
-    display: none !important;
-  }
   
   /* Use border-box sizing by default for all elements */
   *, *::before, *::after {

--- a/packages/asc-ui/src/components/Menu/MenuList/MenuListStyle.ts
+++ b/packages/asc-ui/src/components/Menu/MenuList/MenuListStyle.ts
@@ -1,7 +1,7 @@
 import styled, { css, keyframes } from 'styled-components'
-import { MenuItemStyle } from '../MenuItem'
-import { EdgeDetectionTypes } from '../../../utils/hooks/useEdgeDetection'
 import { showHide } from '../../../utils'
+import { EdgeDetectionTypes } from '../../../utils/hooks/useEdgeDetection'
+import { MenuItemStyle } from '../MenuItem'
 
 export type Props = {
   edgeDetection?: EdgeDetectionTypes
@@ -42,4 +42,8 @@ export default styled.ul<Props>`
     )}
 
   ${showHide()}
+
+  [aria-hidden='true'] {
+    display: none;
+  }
 `

--- a/packages/asc-ui/src/components/Select/Select.stories.mdx
+++ b/packages/asc-ui/src/components/Select/Select.stories.mdx
@@ -74,11 +74,9 @@ to ask multiple questions (text from Design System)
 
 <Preview>
   <Story name="Selected state">
-    <Select id="select-1" label="Label">
+    <Select id="select-1" label="Label" defaultValue="2">
       <option value="1">Option 1</option>
-      <option value="2" selected>
-        Option 2
-      </option>
+      <option value="2">Option 2</option>
       <option value="3">Option 3</option>
       <option value="4">Option 4</option>
     </Select>
@@ -139,5 +137,26 @@ to ask multiple questions (text from Design System)
 <Preview>
   <Story name="With ref">
     <SelectWithRef />
+  </Story>
+</Preview>
+
+## With long text
+
+<Preview>
+  <Story name="With long text">
+    <Select id="select-1" label="Select with long text">
+      <option value="1">
+        Option 1 - with a very very long description that overflows
+      </option>
+      <option value="2">
+        Option 2 - with a very very long description that overflows
+      </option>
+      <option value="3">
+        Option 3 - with a very very long description that overflows
+      </option>
+      <option value="4">
+        Option 4 - with a very very long description that overflows
+      </option>
+    </Select>
   </Story>
 </Preview>

--- a/packages/asc-ui/src/components/Select/SelectStyle.ts
+++ b/packages/asc-ui/src/components/Select/SelectStyle.ts
@@ -1,8 +1,7 @@
-import styled, { css } from 'styled-components'
 import { ChevronDown } from '@datapunt/asc-assets'
+import styled, { css } from 'styled-components'
 import { themeColor, themeSpacing } from '../../utils'
 import { outlineStyle } from '../../utils/themeUtils'
-import { Theme } from '../../types'
 
 export type Props = {
   id?: string
@@ -16,38 +15,62 @@ export type Props = {
   errorStyle?: object
 }
 
-const SelectBoxShadow = (
-  color: ({ theme }: { theme: Theme.ThemeInterface }) => string,
-) => css`
-  box-shadow: inset 0 0 0 1px ${color};
-`
-
-export const SelectIcon = styled(ChevronDown)`
-  position: absolute;
-  display: block;
-  width: ${themeSpacing(3)};
-  height: ${themeSpacing(3)};
-  top: calc(50% - ${themeSpacing(3 / 2)});
-  right: ${themeSpacing(3)};
-`
-
 export const SelectWrapper = styled.div`
   position: relative;
   height: 40px;
   width: 100%;
 `
 
+/**
+ * Contains all of the absolute content which is placed above the select element.
+ */
+export const AbsoluteContentWrapper = styled.div.attrs({
+  'aria-hidden': 'true',
+})`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: 1px ${themeSpacing(3)} 1px ${themeSpacing(3)}; /* Match the border and spacing of the select element. */
+  display: flex;
+  align-items: center;
+  background-color: ${themeColor('tint', 'level1')};
+  pointer-events: none;
+`
+
+/**
+ * Since Chrome does not support `text-overflow: hidden` we need show the value in a separate element.
+ */
+export const SelectedValue = styled.div<{ disabled?: boolean }>`
+  margin-right: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      opacity: 0.5;
+    `}
+`
+export const SelectIcon = styled(ChevronDown)`
+  display: block;
+  width: ${themeSpacing(3)};
+  height: ${themeSpacing(3)};
+  margin-left: ${themeSpacing(3)};
+`
+
 const SelectStyle = styled.select<Props>`
+  position: absolute;
   width: 100%;
   height: 100%;
-  padding: 0 ${themeSpacing(3)};
+  padding: ${themeSpacing(0, 3)};
   font-size: 1rem;
-  border: 0;
+  border: 1px solid ${themeColor('tint', 'level5')};
   border-radius: 0;
   background-color: ${themeColor('tint', 'level1')};
   appearance: none;
   cursor: pointer;
-  ${SelectBoxShadow(themeColor('tint', 'level5'))}
 
   /* IE11 (hide native arrow button) */
   &::-ms-expand {
@@ -71,7 +94,7 @@ const SelectStyle = styled.select<Props>`
       !disabled &&
       !error &&
       css`
-        ${SelectBoxShadow(themeColor('tint', 'level7'))}
+        border: 1px solid ${themeColor('tint', 'level7')};
       `}
   }
 
@@ -85,13 +108,13 @@ const SelectStyle = styled.select<Props>`
   &:disabled {
     pointer-events: none;
     opacity: 0.5;
-    ${SelectBoxShadow(themeColor('tint', 'level4'))};
+    border: 1px solid ${themeColor('tint', 'level4')};
   }
 
   ${({ error }) =>
     error &&
     css`
-      ${SelectBoxShadow(themeColor('error', 'main'))}
+      border: 1px solid ${themeColor('error', 'main')};
     `}
 `
 


### PR DESCRIPTION
This PR adds the capability of long texts in the Select component. When the text is too long, the overflow will be shown with ellipsis.

Closes #614
