### PR TITLE
Added deprecatedWarning + Deprecated the color prop in Typography + Paragraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ Prefix the change with one of these keywords:
 
 ## Unreleased
 
+- Added: general `deprecatedWarning`
+- Deprecated: `color` prop in `Paragraph` and `Typography` components. Instead use your own custom style rules.
 
 ## [0.19.2-beta.3]
 
 - Changed: ContextMenu list is positioned absolute now
-- Added: ContextMenuSelect component, to be used for touchscreens. [Check out the story on how to implement](https://amsterdam.github.io/amsterdam-styled-components/?path=/story/experimental-composed-contextmenu--with-select-on-touch-screen) 
+- Added: ContextMenuSelect component, to be used for touchscreens. [Check out the story on how to implement](https://amsterdam.github.io/amsterdam-styled-components/?path=/story/experimental-composed-contextmenu--with-select-on-touch-screen)
 - Changed: `::after` and `::before` pseudo elements are now also set to `box-sizing: border-box;` by default
 - Changed: HTML5 elements are set to display block for older browsers
 - Added: Supplement colors to default theme

--- a/packages/asc-ui/src/components/Button/ButtonStyle.ts
+++ b/packages/asc-ui/src/components/Button/ButtonStyle.ts
@@ -199,13 +199,11 @@ const getVariant = () => ({
 
 export type Props = {
   /**
-   * Deprecated: Use variant instead. Pass the theme-color.
-   * @deprecated
+   * @deprecated Use variant instead. Pass the theme-color.
    */
   color?: Theme.ColorType
   /**
-   * Deprecated: use size to create a button with equal width and height
-   * @deprecated
+   * @deprecated Use size to create a button with equal width and height
    */
   square?: boolean
   /**

--- a/packages/asc-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/asc-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -7,6 +7,7 @@ import ContextMenuWrapperStyle from './ContextMenuWrapperStyle'
 import ContextMenuItem from './ContextMenuItem'
 import useFocusWithArrows from '../../utils/hooks/useFocusWithArrows'
 import useDetectTouchscreen from '../../utils/hooks/useDetectTouchScreen'
+import { deprecatedWarning } from '../../utils'
 
 export type Props = {
   position?: Position
@@ -36,9 +37,8 @@ const ContextMenu: React.FC<
     React.Children.toArray(children).forEach((child) => {
       // @ts-ignore
       if (child && child.type !== ContextMenuItem) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'Warning: you are rendering a different component type in <ContextMenu /> other than <ContextMenuItem />.',
+        deprecatedWarning(
+          'You are rendering a different component type in <ContextMenu /> other than <ContextMenuItem />.',
         )
       }
     })

--- a/packages/asc-ui/src/components/FilterBox/FilterBox.tsx
+++ b/packages/asc-ui/src/components/FilterBox/FilterBox.tsx
@@ -5,6 +5,7 @@ import FilterBoxStyle, {
   Props as StyleProps,
 } from './FilterBoxStyle'
 import Heading from '../Heading'
+import { themeColor } from '../../utils/themeUtils'
 
 type Props = {
   label: string
@@ -12,6 +13,7 @@ type Props = {
 
 const StyledHeading = styled(Heading)`
   margin-bottom: 0;
+  color: ${themeColor('primary', 'main')};
 `
 
 const FilterBox: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
@@ -21,9 +23,7 @@ const FilterBox: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
 }) => (
   <FilterBoxStyle {...otherProps}>
     <FilterBoxHeader>
-      <StyledHeading forwardedAs="h3" color="primary">
-        {label}
-      </StyledHeading>
+      <StyledHeading forwardedAs="h3">{label}</StyledHeading>
     </FilterBoxHeader>
     {children}
   </FilterBoxStyle>

--- a/packages/asc-ui/src/components/Menu/MenuFlyOut/MenuFlyOut.test.tsx
+++ b/packages/asc-ui/src/components/Menu/MenuFlyOut/MenuFlyOut.test.tsx
@@ -1,6 +1,7 @@
-import { ChevronDown, ChevronUp } from '@datapunt/asc-assets'
-import { mount, ReactWrapper, shallow, ShallowWrapper } from 'enzyme'
 import React from 'react'
+import { mount, ReactWrapper, shallow, ShallowWrapper } from 'enzyme'
+import { act } from '@testing-library/react'
+import { ChevronDown, ChevronUp } from '@datapunt/asc-assets'
 import { KeyboardKeys } from '../../../types'
 import { useMenuContext } from '../MenuContext'
 import MenuFlyOut from '.'
@@ -75,37 +76,41 @@ describe('MenuFlyOut', () => {
   })
 
   it('should toggle the isOpen state on click', () => {
-    onClickSimulate()
-
-    jest.runAllTimers()
+    act(() => {
+      onClickSimulate()
+      jest.runAllTimers()
+    })
 
     menuListProps = component.find(MenuList).props()
     expect(menuListProps['aria-hidden']).toBe(false)
   })
 
   it('should not toggle the isOpen state when already opened', () => {
-    onClickSimulate()
-    onClickSimulate()
-
-    jest.runAllTimers()
+    act(() => {
+      onClickSimulate()
+      onClickSimulate()
+      jest.runAllTimers()
+    })
 
     menuListProps = component.find(MenuList).props()
     expect(menuListProps['aria-hidden']).toBe(false)
   })
 
   it('should toggle the isOpen state on enter', () => {
-    onKeyDownSimulate('Enter')
-
-    jest.runAllTimers()
+    act(() => {
+      onKeyDownSimulate('Enter')
+      jest.runAllTimers()
+    })
 
     menuListProps = component.find(MenuList).props()
     expect(menuListProps['aria-hidden']).toBe(false)
   })
 
   it('should toggle the isOpen state on space', () => {
-    onKeyDownSimulate('Space')
-
-    jest.runAllTimers()
+    act(() => {
+      onKeyDownSimulate('Space')
+      jest.runAllTimers()
+    })
 
     menuListProps = component.find(MenuList).props()
     expect(menuListProps['aria-hidden']).toBe(false)
@@ -119,8 +124,9 @@ describe('MenuFlyOut', () => {
     }))
 
     container = mount<{}>(<MenuFlyOut label="Fly Out">{children}</MenuFlyOut>)
-
-    onClickSimulate(container)
+    act(() => {
+      onClickSimulate(container)
+    })
 
     expect(onExpandMock).toHaveBeenCalled()
   })
@@ -146,9 +152,10 @@ describe('MenuFlyOut', () => {
       menuListProps = component.find(MenuList).props()
       expect(menuListProps['aria-hidden']).toBe(true)
 
-      onClickSimulate()
-
-      jest.runAllTimers()
+      act(() => {
+        onClickSimulate()
+        jest.runAllTimers()
+      })
 
       expect(menuItemLink.find(<ChevronUp />)).toBeTruthy()
 

--- a/packages/asc-ui/src/components/SearchBar/SearchBar.tsx
+++ b/packages/asc-ui/src/components/SearchBar/SearchBar.tsx
@@ -6,6 +6,7 @@ import { InputProps } from '../Input'
 import InputContext from '../Input/InputMethodsContext'
 import TextField, { TextFieldProps } from '../TextField/TextField'
 import SearchBarStyle, { Props as SearchBarStyleProps } from './SearchBarStyle'
+import { deprecatedWarning } from '../../utils'
 
 export interface SearchBarProps extends TextFieldProps, SearchBarStyleProps {
   label?: string
@@ -56,8 +57,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
 
   const handleOnSubmit = (e: React.FormEvent) => {
     if (onSubmit) {
-      // eslint-disable-next-line no-console
-      console.warn(
+      deprecatedWarning(
         `onSubmit is about to be deprecated, wrap this component inside a <form onSubmit={...} /> instead`,
       )
       onSubmit(e)
@@ -74,8 +74,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
 
   React.useEffect(() => {
     if (onWatchValue) {
-      // eslint-disable-next-line no-console
-      console.warn(
+      deprecatedWarning(
         'onWatchValue is about to be deprecated. Use onChange in combo with onClear instead',
       )
       // @ts-ignore

--- a/packages/asc-ui/src/components/Typography/Typography.tsx
+++ b/packages/asc-ui/src/components/Typography/Typography.tsx
@@ -2,11 +2,17 @@ import React from 'react'
 import TypographyStyle, {
   Props as TypographyStyleProps,
 } from './TypographyStyle'
+import { deprecatedWarning } from '../../utils'
 
 export type Props = TypographyStyleProps & React.HTMLAttributes<HTMLElement>
 
-const Typography: React.FC<Props> = ({ children, ...otherProps }) => (
-  <TypographyStyle {...otherProps}>{children}</TypographyStyle>
-)
+const Typography: React.FC<Props> = ({ children, ...otherProps }) => {
+  if (otherProps.color) {
+    deprecatedWarning(
+      'You are using the deprecated `color` prop in the `Typography` component. Please use your own custom style rules',
+    )
+  }
+  return <TypographyStyle {...otherProps}>{children}</TypographyStyle>
+}
 
 export default Typography

--- a/packages/asc-ui/src/components/Typography/TypographyStyle.ts
+++ b/packages/asc-ui/src/components/Typography/TypographyStyle.ts
@@ -5,12 +5,16 @@ import { Theme } from '../../types'
 export type Props = {
   gutterBottom?: number
   element?: Variant
-  color?: Theme.ColorType
   fontSize?: number
   styleAs?: keyof Theme.TypographyElements
   as?: any
   forwardedAs?: any
   strong?: boolean
+  /**
+   * Deprecated: Use your own custom style rules
+   * @deprecated
+   */
+  color?: Theme.ColorType
 }
 
 export const defaultTypographyStyles = {

--- a/packages/asc-ui/src/components/Typography/TypographyStyle.ts
+++ b/packages/asc-ui/src/components/Typography/TypographyStyle.ts
@@ -11,8 +11,7 @@ export type Props = {
   forwardedAs?: any
   strong?: boolean
   /**
-   * Deprecated: Use your own custom style rules
-   * @deprecated
+   * @deprecated Use your own custom style rules
    */
   color?: Theme.ColorType
 }

--- a/packages/asc-ui/src/types/Theme.ts
+++ b/packages/asc-ui/src/types/Theme.ts
@@ -103,12 +103,16 @@ export namespace Theme {
       SupportPaletteInterface {}
 
   export type TypographyElementStyle = {
-    color: CSSProp
     fontWeight: 400 | 500 | 700 | 'inherit'
     fontSize: CSSProp
     lineHeight: number | CSSProp
     letterSpacing: CSSProp
     marginBottom: CSSProp
+    /**
+     * Deprecated: Use your own custom style rules
+     * @deprecated
+     */
+    color: CSSProp
   }
 
   export interface TypographyType extends Partial<TypographyElementStyle> {

--- a/packages/asc-ui/src/types/Theme.ts
+++ b/packages/asc-ui/src/types/Theme.ts
@@ -109,8 +109,7 @@ export namespace Theme {
     letterSpacing: CSSProp
     marginBottom: CSSProp
     /**
-     * Deprecated: Use your own custom style rules
-     * @deprecated
+     * @deprecated Use your own custom style rules
      */
     color: CSSProp
   }

--- a/packages/asc-ui/src/utils/deprecatedWarning.ts
+++ b/packages/asc-ui/src/utils/deprecatedWarning.ts
@@ -1,0 +1,8 @@
+/**
+ * A general deprecated console warning avoided by lint
+ */
+
+export default (message: String) => {
+  // eslint-disable-next-line
+  console.warn(message)
+}

--- a/packages/asc-ui/src/utils/index.ts
+++ b/packages/asc-ui/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { getValueFromTheme } from './themeUtils'
+import deprecatedWarning from './deprecatedWarning'
 
 export {
   themeColor,
@@ -24,4 +25,4 @@ export { fromProps } from './fromProps'
  */
 const fromTheme = getValueFromTheme
 
-export { fromTheme }
+export { fromTheme, deprecatedWarning }


### PR DESCRIPTION
- Added a general deprecated console warning avoided by lint
- Deprecated the `color` prop in `Typography`
- Fixed test warnings from `MenuFlyOut/MenuFlyOut.test.tsx`