### PR TITLE
Fix: removed the compact prop/variant in Alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Prefix the change with one of these keywords:
 
 ## Unreleased
 
+- Changed: **BREAKING** removed the `compact` prop/variant in `Alert`
+- Changed: updated the styling of `Alert` conform to design system
+
 ## [0.20.0]
 
 - Changed: ContextMenu list is positioned absolute now

--- a/packages/asc-ui/src/components/Alert/Alert.stories.mdx
+++ b/packages/asc-ui/src/components/Alert/Alert.stories.mdx
@@ -34,43 +34,6 @@ export const Decorator = styled.div`
       <Alert level="attention">Attention</Alert>
       <Alert level="error">Error</Alert>
       <Alert level="warning">Warning</Alert>
-      <Alert compact>Normal compact</Alert>
-      <Alert compact level="attention">
-        Attention compact
-      </Alert>
-      <Alert compact level="warning">
-        Warning compact
-      </Alert>
-      <Alert compact level="error">
-        Error compact
-      </Alert>
-    </React.Fragment>
-  </Story>
-</Preview>
-
-## Compact state of Alert
-
-<Preview>
-  <Story name="Compact State">
-    <React.Fragment>
-      <Alert
-        content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error, vitae."
-        compact
-      />
-      <Alert
-        content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error, vitae."
-        compact
-        dismissible
-        level="attention"
-      />
-      <Alert heading="Only heading with button" compact level="warning" />
-      <Alert
-        content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error, vitae."
-        compact
-        dismissible
-        level="error"
-        heading="With heading, content and button"
-      />
     </React.Fragment>
   </Story>
 </Preview>

--- a/packages/asc-ui/src/components/Alert/Alert.tsx
+++ b/packages/asc-ui/src/components/Alert/Alert.tsx
@@ -18,7 +18,6 @@ const Alert: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
   heading,
   onDismiss,
   dismissible,
-  compact,
   content,
   level,
   ...otherProps
@@ -43,16 +42,16 @@ const Alert: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
 
   return open ? (
     <AlertStyle
-      {...{ compact, dismissible, level, ...otherProps }}
+      {...{ dismissible, level, ...otherProps }}
       tabIndex={0}
       role="alert"
       aria-live="polite"
     >
       <CompactThemeProvider>
-        <ContentWrapper compact={compact}>
+        <ContentWrapper>
           {heading && (
             // @ts-ignore
-            <AlertHeading forwardedAs="strong" styleAs={compact ? 'h5' : 'h3'}>
+            <AlertHeading forwardedAs="strong" styleAs="h3">
               {heading}
             </AlertHeading>
           )}
@@ -61,14 +60,14 @@ const Alert: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
           {children}
         </ContentWrapper>
         {dismissible && (
-          <CloseButtonWrapper compact={compact}>
+          <CloseButtonWrapper>
             <CloseButton
               title={CLOSE_BUTTON_TITLE}
               aria-label={CLOSE_BUTTON_TITLE}
-              size={compact ? 24 : 30}
+              size={30}
               variant={variant}
               onClick={handleOnDismiss}
-              iconSize={compact ? 16 : 20}
+              iconSize={20}
               icon={<Close />}
             />
           </CloseButtonWrapper>

--- a/packages/asc-ui/src/components/Alert/AlertStyle.ts
+++ b/packages/asc-ui/src/components/Alert/AlertStyle.ts
@@ -11,17 +11,13 @@ import Heading from '../Heading'
 
 export type Level = 'normal' | 'attention' | 'warning' | 'error'
 
-type SharedProps = {
-  compact?: boolean
-}
-
 export type Props = {
   level?: Level
   heading?: string
   onDismiss?: () => void
   content?: string
   dismissible?: boolean
-} & SharedProps
+}
 
 const colorMap: Record<
   Level,
@@ -33,34 +29,20 @@ const colorMap: Record<
   error: themeColor('secondary'),
 }
 
-const getVPadding = (compact?: boolean) => (compact ? 2 : 5)
-const getHPadding = (compact?: boolean) => (compact ? 1 : 6)
-
-export const CloseButtonWrapper = styled.div<SharedProps>`
+export const CloseButtonWrapper = styled.div`
   display: flex;
   flex-direction: column;
   margin-left: auto;
-
-  &::before,
-  &::after {
-    content: '';
-    height: 100%;
-    max-height: ${({ compact, theme }) =>
-      themeSpacing(getHPadding(compact))({ theme })};
-  }
 `
 
 export const CloseButton = styled(Button)`
   background-color: transparent;
 `
 
-export const ContentWrapper = styled.div<SharedProps>`
+export const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  ${({ compact, theme }) =>
-    css`
-      padding: ${themeSpacing(getHPadding(compact), 0)({ theme })};
-    `}
+  justify-content: center;
 
   & > * {
     &:last-child {
@@ -75,12 +57,19 @@ export const AlertHeading = styled(Heading)`
 
 export default styled.div<Props>`
   position: relative;
-  display: flex;
   width: 100%; /* IE11 fix */
   ${focusStyleOutline()}
-  ${({ level, compact, theme }) =>
+
+  /* IE11 fix: display 'flex' only when dismissible */
+  ${({ dismissible }) =>
+    dismissible &&
     css`
-      padding: ${themeSpacing(0, getVPadding(compact))({ theme })};
+      display: flex;
+    `}
+
+  ${({ level, theme }) =>
+    css`
+      padding: ${themeSpacing(4)};
 
       /* Colors */
       background-color: ${colorMap[level || 'normal']({


### PR DESCRIPTION
- removed `compact` prop/variant for Alert
- updated the styling conform to design system
- updated `AlertStyle` to make component easier customisable 
- IE11 fix: display 'flex' only when dismissible