### PR TITLE
Radio and Checkbox now have a white background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,15 @@ Prefix the change with one of these keywords:
 
 ## Unreleased
 
-- Changed: **BREAKING** indeterminate state on checkbox should only work when `checked === false` and not truthy. 
-This also inverts behaviour when clicking on an indeterminate checkbox: it will enable all instead of disable all first
+- Changed: **BREAKING** indeterminate state on checkbox should only work when `checked === false` and not truthy.
+- Added: Form elements Checkbox and Radio now have a white background (instead of transparent) (see [PR](https://github.com/Amsterdam/amsterdam-styled-components/pull/875)).
 
 ## [0.22.0]
+
 - Changed: Introduced `createEvent` utility to support creating events in older browsers.
 - Removed: **BREAKING** previously marked deprecated components
 - Changed: Link component works better on dark backgrounds
-- Changed: **BREAKING** Footer components. Check out footer story for example on usage 
+- Changed: **BREAKING** Footer components. Check out footer story for example on usage
 - Added: Export `SelectWrapperStyle`
 - Changed: **BREAKING** set height of input and select elements to 44px (from 40px) to match the design system
 - Added: Make it possible to programmatically set the value and value label for the select component

--- a/packages/asc-ui/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/asc-ui/src/components/Checkbox/Checkbox.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { render, cleanup, fireEvent } from '@testing-library/react'
 import Checkbox from './Checkbox'
-import { ThemeProvider } from '../../theme'
+import { ascDefaultTheme, ThemeProvider } from '../../theme'
+import { themeColor } from '../../utils'
 
 describe('Checkbox', () => {
   let container: any
@@ -21,24 +22,36 @@ describe('Checkbox', () => {
     const checkBox = container.querySelector('input')
     const icon = container.querySelector('span')
 
-    expect(icon).not.toHaveStyleRule('background-color', expect.any(String))
+    expect(icon).toHaveStyleRule(
+      'background-color',
+      themeColor('tint', 'level1')({ theme: ascDefaultTheme }),
+    )
 
     // Toggle on
     fireEvent.click(checkBox)
 
     expect(onChangeMock).toHaveBeenCalled()
-    expect(icon).toHaveStyleRule('background-color', expect.any(String))
+    expect(icon).not.toHaveStyleRule(
+      'background-color',
+      themeColor('tint', 'level1')({ theme: ascDefaultTheme }),
+    )
 
     // Toggle off
     fireEvent.click(checkBox)
 
-    expect(icon).not.toHaveStyleRule('background-color', expect.any(String))
+    expect(icon).toHaveStyleRule(
+      'background-color',
+      themeColor('tint', 'level1')({ theme: ascDefaultTheme }),
+    )
   })
 
   it('should toggle checked / not checked when the props change', () => {
     const icon = container.querySelector('span')
 
-    expect(icon).not.toHaveStyleRule('background-color', expect.any(String))
+    expect(icon).toHaveStyleRule(
+      'background-color',
+      themeColor('tint', 'level1')({ theme: ascDefaultTheme }),
+    )
 
     // Toggle on by changing props
     rerender(
@@ -47,7 +60,10 @@ describe('Checkbox', () => {
       </ThemeProvider>,
     )
 
-    expect(icon).toHaveStyleRule('background-color', expect.any(String))
+    expect(icon).not.toHaveStyleRule(
+      'background-color',
+      themeColor('tint', 'level1')({ theme: ascDefaultTheme }),
+    )
 
     // Toggle of by changing props
     rerender(
@@ -56,7 +72,10 @@ describe('Checkbox', () => {
       </ThemeProvider>,
     )
 
-    expect(icon).not.toHaveStyleRule('background-color', expect.any(String))
+    expect(icon).toHaveStyleRule(
+      'background-color',
+      themeColor('tint', 'level1')({ theme: ascDefaultTheme }),
+    )
   })
 
   it('should handle refs', () => {

--- a/packages/asc-ui/src/components/Checkbox/CheckboxStyle.ts
+++ b/packages/asc-ui/src/components/Checkbox/CheckboxStyle.ts
@@ -68,12 +68,13 @@ const CheckboxIconStyle = styled(IconStyle)<Props>`
   position: relative;
   justify-content: center;
   align-items: center;
+  background-color: ${themeColor('tint', 'level1')};
   transition: background-color 0.2s ease-in-out;
   ${({ checked, indeterminate }) =>
     (checked || indeterminate) &&
     css`
       ${getVariant()};
-    `}
+    `};
 `
 
 const CheckboxWrapperStyle = styled.div<Props & { focus: boolean }>`

--- a/packages/asc-ui/src/components/Radio/RadioStyle.ts
+++ b/packages/asc-ui/src/components/Radio/RadioStyle.ts
@@ -62,6 +62,7 @@ const RadioCircleStyle = styled.span<StyleOnlyProps>`
   width: 24px;
   height: 24px;
   color: ${themeColor('tint', 'level5')};
+  background-color: ${themeColor('tint', 'level1')};
   border: 1px solid;
   border-radius: 50%;
 


### PR DESCRIPTION
The Checkbox and Radio had a transparent background:
![image](https://user-images.githubusercontent.com/7781865/88544583-ea301180-d019-11ea-8abc-a65cfb572571.png)
![image](https://user-images.githubusercontent.com/7781865/88544599-f025f280-d019-11ea-84d4-2b6df1987d55.png)

And now they're white:
![image](https://user-images.githubusercontent.com/7781865/88544974-970a8e80-d01a-11ea-9105-943c81e39120.png)
![image](https://user-images.githubusercontent.com/7781865/88544978-9bcf4280-d01a-11ea-9806-c8147dac2ea8.png)

