### PR TITLE
Removed style rule max-width from FormTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Prefix the change with one of these keywords:
 
 ## Unreleased
 
+- Removed: style rule `max-width: 620px` from FormTitle
 - Added: A new experimental `Tabs` component for tabbed content.
 - Deprecated: `icon` prop now only accepts strings: `download` or `external`. If you want to use a custom icon, please pass it as a child
 - Changed: `icon` prop to render a download or external link icon

--- a/packages/asc-ui/src/components/FormTitle/FormTitle.test.tsx
+++ b/packages/asc-ui/src/components/FormTitle/FormTitle.test.tsx
@@ -22,7 +22,6 @@ describe('FormTitle', () => {
       </ThemeProvider>,
     )
 
-    expect(container.firstChild).toHaveStyleRule('max-width', '620px')
     expect(container.firstChild).toHaveStyleRule('font-size', '14px')
     expect(container.firstChild).toHaveStyleRule('line-height', '18px')
     expect(container.firstChild).toHaveStyleRule('font-weight', '700')

--- a/packages/asc-ui/src/components/FormTitle/FormTitleStyle.ts
+++ b/packages/asc-ui/src/components/FormTitle/FormTitleStyle.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import { themeColor, themeSpacing } from '../../utils/themeUtils'
 
 export default styled.h1`
-  max-width: 620px;
   margin: ${themeSpacing(6, 0, 8)};
   padding-bottom: ${themeSpacing(1)};
   border-bottom: 1px solid ${themeColor('tint', 'level5')};

--- a/stories/src/ui/FormTitle.stories.mdx
+++ b/stories/src/ui/FormTitle.stories.mdx
@@ -9,7 +9,7 @@ import {
 } from '@datapunt/asc-ui'
 
 <Meta
-  title="UI/FormTitle"
+  title="UI/Form/FormTitle"
   component={FormTitle}
   decorators={[
     (storyFn) => (


### PR DESCRIPTION
Better to set in your project by giving the wrapper a max-width