### PR TITLE
Ignore pointer events on Checkbox icon

### DIFF
--- a/packages/asc-ui/src/components/Checkbox/CheckboxStyle.ts
+++ b/packages/asc-ui/src/components/Checkbox/CheckboxStyle.ts
@@ -69,6 +69,7 @@ const CheckboxIconStyle = styled(IconStyle)<Props>`
   z-index: 1;
   background-color: ${themeColor('tint', 'level1')};
   transition: background-color 0.2s ease-in-out;
+  pointer-events: none;
   ${({ checked, indeterminate }) =>
     (checked || indeterminate) &&
     css`


### PR DESCRIPTION
Fixes a bug where the checkbox cannot be toggled if it does not have a label.
