### PR TITLE
Buttons need to be at least 90px width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Prefix the change with one of these keywords:
 
 ## Unreleased
 
+- Fixed: Buttons need to be at least 90px width
 - Changed: Changed Tabs TabButton `color` in accordance with Design System, added padding to tab content in Tabs stories
 - Changed: Tabs container fade is now same width as tab-button right margin
 - Fixed: Icon overlay of Checkbox now ignores pointer events

--- a/packages/asc-ui/src/components/Button/ButtonStyle.ts
+++ b/packages/asc-ui/src/components/Button/ButtonStyle.ts
@@ -51,6 +51,7 @@ const getVariant = () => ({
   switch (variant) {
     case 'primary':
       return css`
+        min-width: 90px;
         background-color: ${themeColor('primary')};
         color: ${readableColor(themeColor('primary')({ theme }))};
         ${svgFill(themeColor('tint', 'level1'))};
@@ -62,6 +63,7 @@ const getVariant = () => ({
 
     case 'secondary':
       return css`
+        min-width: 90px;
         background-color: ${themeColor('secondary')};
         color: ${themeColor('tint', 'level1')};
         ${svgFill(themeColor('tint', 'level1'))};
@@ -84,6 +86,7 @@ const getVariant = () => ({
 
     case 'tertiary':
       return css`
+        min-width: 90px;
         background-color: ${themeColor('tint', 'level4')};
         ${svgFill(themeColor('tint', 'level7'))};
 
@@ -97,6 +100,7 @@ const getVariant = () => ({
 
     case 'primaryInverted':
       return css`
+        min-width: 90px;
         color: ${themeColor('primary')};
         border: 1px solid ${themeColor('primary')};
         background-color: ${themeColor('tint', 'level1')};


### PR DESCRIPTION
According to the [design system](https://designsystem.amsterdam.nl/7awj1hc9f/p/25ff19-buttons/t/a148) the Buttons should be at least 90px width. In my project I'm having a bug with a Button with very small text. This should fix it.

I'm only applying this on primary, secondary and tertiary variants.

## Issue (example):
![image](https://user-images.githubusercontent.com/7781865/92502976-e12d8500-f200-11ea-9ca3-93784e50d961.png)

## Solution:
![image](https://user-images.githubusercontent.com/7781865/92503121-12a65080-f201-11ea-9f30-ac8484139927.png)

NB: prettier is really annoying by automatically changing files that causes eslint to fail 😠 