### PR TITLE
Added new variants to `Alert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Prefix the change with one of these keywords:
 
 ## Unreleased
 
+- Added: `valid` and `focus` variants to `Alert` (green and yellow colors)
+
 ## [0.24.0]
 
 - Fixed: Buttons need to be at least 90px width

--- a/packages/asc-ui/src/components/Alert/AlertStyle.ts
+++ b/packages/asc-ui/src/components/Alert/AlertStyle.ts
@@ -4,7 +4,13 @@ import { svgFill, themeColor, themeSpacing } from '../../utils'
 import Button from '../Button'
 import Heading from '../Heading'
 
-export type Level = 'normal' | 'attention' | 'warning' | 'error'
+export type Level =
+  | 'normal'
+  | 'attention'
+  | 'warning'
+  | 'error'
+  | 'valid'
+  | 'focus'
 
 export type Props = {
   level?: Level
@@ -22,6 +28,8 @@ const colorMap: Record<
   attention: themeColor('primary'),
   warning: themeColor('tint', 'level1'),
   error: themeColor('secondary'),
+  valid: themeColor('support', 'valid'),
+  focus: themeColor('support', 'focus'),
 }
 
 export const CloseButtonWrapper = styled.div`
@@ -70,7 +78,7 @@ export default styled.div<Props>`
       background-color: ${colorMap[level || 'normal']({
         theme,
       })};
-      ${(level === 'attention' || level === 'error') &&
+      ${(level === 'attention' || level === 'error' || level === 'valid') &&
       css`
         ${svgFill(themeColor('tint', 'level1'))}
         &, & * {

--- a/stories/src/ui/Alert.stories.mdx
+++ b/stories/src/ui/Alert.stories.mdx
@@ -23,7 +23,7 @@ There are three levels of Alerts you can pass through the `level` prop:
 1. Not passing a `level` prop: this is a "normal" Alert, used to inform
 2. `attention`: This is being used to help the user to take action. This usually contains links.
 3. `error`: Use this to inform the user something went wrong, for example a failed request.
-4. `warning`: Use this to warn the user about something and help him to take action.
+4. `warning`, `valid` and `focus`: Use these to warn the user about something and help him to take action.
 
 **Component status: stable**
 
@@ -36,6 +36,8 @@ There are three levels of Alerts you can pass through the `level` prop:
       <Alert level="attention">Attention</Alert>
       <Alert level="error">Error</Alert>
       <Alert level="warning">Warning</Alert>
+      <Alert level="valid">Valid</Alert>
+      <Alert level="focus">Focus</Alert>
     </React.Fragment>
   </Story>
 </Preview>


### PR DESCRIPTION
## Update: we had a discussion with the DS and they're first going to update the design and re-think about the colors. After that we're going to revisit this PR.


### This PR is all about adding the two new variants for the `Alert` component: `valid` and `focus`. As discussed with DT. 

<hr>

<img src="https://user-images.githubusercontent.com/7781865/93104349-05301100-f6ae-11ea-884b-c698a75ce2c0.png"  />

### I named them according to their color-name

<hr>

<img src="https://user-images.githubusercontent.com/7781865/93104312-f8abb880-f6ad-11ea-82f2-ebd1d913357a.png" width=75% />
