### PR TITLE
Radio button active state had bug on IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Prefix the change with one of these keywords:
 ## [0.24.1]
 
 - Fixed: alert close button overrides min-width
+- Fixed: Radio button active state had bug on IE11
 
 ## [0.24.0]
 

--- a/packages/asc-ui/src/components/Radio/RadioStyle.ts
+++ b/packages/asc-ui/src/components/Radio/RadioStyle.ts
@@ -76,6 +76,7 @@ const RadioCircleStyle = styled.span<StyleOnlyProps>`
     top: 50%;
     background-color: ${getVariantColor()};
     opacity: 0;
+    z-index: 1;
     ${({ checked }) =>
       checked &&
       css`


### PR DESCRIPTION
The problem with the active state was that it was missing a `z-index`. After adding this, it's working again.

![image](https://user-images.githubusercontent.com/7781865/93441950-2d975580-f8d0-11ea-8a09-7316c9ebd5af.png)

#1165 