### PR TITLE
Updated variants/levels for Alert component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Prefix the change with one of these keywords:
 - Fixed: `Tag` component width is now displayed correctly in IE11 (https://github.com/Amsterdam/amsterdam-styled-components/issues/634)
 - Changed: Most of the documentation has been re-written to use the MDX file format (https://github.com/Amsterdam/amsterdam-styled-components/issues/558)
 - Changed: `Button` component now changes background color when focussed (https://github.com/Amsterdam/amsterdam-styled-components/pull/1296)
+- Changed: **BREAKING** the `Alert` levels have been modified to align to their respective function (https://github.com/Amsterdam/amsterdam-styled-components/pull/1295)
+
 
 ## [0.25.2]
 

--- a/packages/asc-ui/src/components/Alert/Alert.tsx
+++ b/packages/asc-ui/src/components/Alert/Alert.tsx
@@ -15,20 +15,23 @@ const CLOSE_BUTTON_TITLE = 'Sluiten'
 
 const Alert: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
   children,
-  heading,
-  onDismiss,
-  dismissible,
   content,
+  dismissible,
+  heading,
   level,
+  onDismiss,
+  outline,
   ...otherProps
 }) => {
   const [open, setOpen] = useState(true)
 
   let variant: ButtonVariant = 'tertiary'
 
-  if (level === 'error') {
+  if (outline) {
+    variant = 'blank'
+  } else if (level === 'error') {
     variant = 'secondary'
-  } else if (level === 'attention') {
+  } else if (level === 'info') {
     variant = 'primary'
   }
 
@@ -42,7 +45,7 @@ const Alert: React.FC<Props & React.HTMLAttributes<HTMLElement>> = ({
 
   return open ? (
     <AlertStyle
-      {...{ dismissible, level, ...otherProps }}
+      {...{ dismissible, level, outline, ...otherProps }}
       tabIndex={0}
       role="alert"
       aria-live="polite"

--- a/packages/asc-ui/src/components/Alert/AlertStyle.ts
+++ b/packages/asc-ui/src/components/Alert/AlertStyle.ts
@@ -4,24 +4,25 @@ import { svgFill, themeColor, themeSpacing } from '../../utils'
 import Button from '../Button'
 import Heading from '../Heading'
 
-export type Level = 'normal' | 'attention' | 'warning' | 'error'
+export type Level = 'error' | 'info' | 'neutral' | 'warning'
 
 export type Props = {
-  level?: Level
-  heading?: string
-  onDismiss?: () => void
   content?: string
   dismissible?: boolean
+  heading?: string
+  level?: Level
+  onDismiss?: () => void
+  outline?: boolean
 }
 
 const colorMap: Record<
   Level,
   ({ theme }: { theme: Theme.ThemeInterface }) => string
 > = {
-  normal: themeColor('tint', 'level3'),
-  attention: themeColor('primary'),
-  warning: themeColor('tint', 'level1'),
-  error: themeColor('secondary'),
+  error: themeColor('error'),
+  info: themeColor('primary'),
+  neutral: themeColor('tint', 'level3'),
+  warning: themeColor('support', 'focus'),
 }
 
 export const CloseButtonWrapper = styled.div`
@@ -63,24 +64,38 @@ export default styled.div<Props>`
       display: flex;
     `}
 
-  ${({ level, theme }) =>
+  ${({ level, outline, theme }) =>
     css`
       padding: ${themeSpacing(4)};
 
-      /* Colors */
-      background-color: ${colorMap[level || 'normal']({
-        theme,
-      })};
-      ${(level === 'attention' || level === 'error') &&
+      /* Solid colors */
+      ${!outline &&
+      css`
+        background-color: ${colorMap[level || 'neutral']({
+          theme,
+        })};
+      `}
+      ${!outline &&
+      (level === 'error' || level === 'info') &&
       css`
         ${svgFill(themeColor('tint', 'level1'))}
         &, & * {
           color: ${themeColor('tint', 'level1')};
         }
       `}
-      ${level === 'warning' &&
+      
+      /* Outline color */
+      ${outline &&
       css`
-        box-shadow: ${themeColor('secondary')} 0px 0px 0px 2px inset;
+        box-shadow: ${colorMap[level || 'neutral']({
+            theme,
+          })}
+          0px 0px 0px 2px inset;
+      `}
+      ${outline &&
+      (level === 'error' || level === 'info') &&
+      css`
+        ${svgFill(themeColor('tint', 'level7'))}
       `}
     `}
 `

--- a/stories/src/ui/Alert.stories.mdx
+++ b/stories/src/ui/Alert.stories.mdx
@@ -18,12 +18,14 @@ export const Decorator = styled.div`
 
 [Design System](https://designsystem.amsterdam.nl/7awj1hc9f/p/901ede-alert)
 
-There are three levels of Alerts you can pass through the `level` prop:
+There are four levels of Alerts you can pass through the `level` prop:
 
-1. Not passing a `level` prop: this is a "normal" Alert, used to inform
-2. `attention`: This is being used to help the user to take action. This usually contains links.
-3. `error`: Use this to inform the user something went wrong, for example a failed request.
-4. `warning`: Use this to warn the user about something and help him to take action.
+1. `neutral`: This is the default level and is used to inform the user. (gray color)
+2. `error`: Use this to inform the user something went wrong, for example a failed request. (red color)
+3. `info`: This is being used to help the user to take action. (blue color)
+4. `warning`: Use this to warn the user about something and help him to take action. (yellow color)
+
+The prop `outline` places the color on the outline, instead of the background of the Alert
 
 **Component status: stable**
 
@@ -32,10 +34,14 @@ There are three levels of Alerts you can pass through the `level` prop:
 <Preview>
   <Story name="Variants">
     <React.Fragment>
-      <Alert>Normal</Alert>
-      <Alert level="attention">Attention</Alert>
+      <Alert>Neutral</Alert>
       <Alert level="error">Error</Alert>
+      <Alert level="info">Info</Alert>
       <Alert level="warning">Warning</Alert>
+      <br />
+      <Alert level="error" outline>
+        Error (outline)
+      </Alert>
     </React.Fragment>
   </Story>
 </Preview>
@@ -46,26 +52,21 @@ There are three levels of Alerts you can pass through the `level` prop:
   <Story name="With content and heading">
     <React.Fragment>
       <Alert
-        level="normal"
+        level="neutral"
         heading="With a heading and content"
-        content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error, vitae."
-      />
-      <Alert
-        dismissible
-        level="attention"
-        content="Without header, with close button"
-      />
-      <Alert
-        dismissible
-        level="warning"
-        heading="With a heading, content and close button"
-        content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error, vitae."
+        content="Lorem ipsum dolor sit amet, consectetur adipisicing elit."
       />
       <Alert
         dismissible
         level="error"
+        content="Without header, with close button"
+        outline
+      />
+      <Alert
+        dismissible
+        level="info"
         heading="With a heading, content and close button"
-        content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error, vitae."
+        content="Lorem ipsum dolor sit amet, consectetur adipisicing elit."
       />
     </React.Fragment>
   </Story>
@@ -76,30 +77,38 @@ There are three levels of Alerts you can pass through the `level` prop:
 <Preview>
   <Story name="With custom children">
     <React.Fragment>
-      <Alert level="warning" dismissible>
-        <Heading>With a normal heading and paragraph</Heading>
+      <Alert level="neutral">
+        <Heading>With a large heading</Heading>
+      </Alert>
+      <Alert level="error" dismissible>
+        <Heading forwardedAs="h2">
+          With a neutral heading, paragraph and closing button
+        </Heading>
         <Paragraph>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Error,
           vitae.
         </Paragraph>
       </Alert>
-      <Alert level="attention" dismissible>
+      <Alert level="warning">
+        <Paragraph strong>Only a strong paragraph</Paragraph>
+      </Alert>
+      <Alert level="info" dismissible>
         <Paragraph>
-          Just a looooong paragraph with close button: Lorem ipsum dolor sit
-          amet, consectetur adipisicing elit. Aut itaque necessitatibus
-          officiis, quasi quia quisquam sit ut! Dolorum excepturi, inventore!
-          Accusamus ad illo molestiae vel. Deleniti excepturi iusto neque
-          quisquam!
+          Just a looooong paragraph with a link and a closing button: Lorem
+          ipsum dolor sit amet, consectetur adipisicing elit. Aut itaque
+          necessitatibus officiis, quasi quia quisquam sit ut! Dolorum
+          excepturi, inventore! Accusamus ad illo molestiae vel. Deleniti
+          excepturi iusto neque quisquam!
         </Paragraph>
         <Link href="/" variant="with-chevron" darkBackground>
           A link
         </Link>
       </Alert>
-      <Alert level="error" dismissible>
+      <Alert level="error" dismissible outline>
         <Heading as="h3">A header</Heading>
         <Paragraph>With a paragraph</Paragraph>
-        <Link href="/" variant="with-chevron" darkBackground>
-          A link
+        <Link href="/" variant="with-chevron">
+          And a link
         </Link>
       </Alert>
     </React.Fragment>


### PR DESCRIPTION
### Updated Alert variants as discussed with @chrisvanmook and @jonkoops. 

I created four levels (colors) and the option to set the color as outline (instead of the background)

Result:
<img src=https://user-images.githubusercontent.com/7781865/97459123-b7105d80-193b-11eb-995d-32d139ff363b.png width=50% />

Related issue: #1245 
Related Trello card: https://trello.com/c/VyP5R53K/348-alerts-kleur-voorstel