### PR TITLE
Added background color to the Button focus state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Prefix the change with one of these keywords:
 - Fixed: `Modal` component no longer produces `zIndexOffset` exceptions (https://github.com/Amsterdam/amsterdam-styled-components/issues/1289)
 - Fixed: `Tag` component width is now displayed correctly in IE11 (https://github.com/Amsterdam/amsterdam-styled-components/issues/634)
 - Changed: Most of the documentation has been re-written to use the MDX file format (https://github.com/Amsterdam/amsterdam-styled-components/issues/558)
+- Changed: `Button` component now changes background color when focussed (https://github.com/Amsterdam/amsterdam-styled-components/pull/1296)
 
 ## [0.25.2]
 

--- a/packages/asc-ui/src/components/Button/ButtonStyle.ts
+++ b/packages/asc-ui/src/components/Button/ButtonStyle.ts
@@ -57,6 +57,7 @@ const getVariant = () => ({
         color: ${readableColor(themeColor('primary')({ theme }))};
         ${svgFill(themeColor('tint', 'level1'))};
 
+        &:focus,
         &:hover {
           background-color: ${darken(0.1, themeColor('primary')({ theme }))};
         }
@@ -69,6 +70,7 @@ const getVariant = () => ({
         color: ${themeColor('tint', 'level1')};
         ${svgFill(themeColor('tint', 'level1'))};
 
+        &:focus,
         &:hover {
           background-color: ${darken(0.1, themeColor('secondary')({ theme }))};
         }
@@ -76,7 +78,10 @@ const getVariant = () => ({
         ${(taskflow) =>
           taskflow &&
           css`
-            &:not(:disabled)&:hover ${ArrowRight} {
+            &:not(:disabled)&:focus
+              ${ArrowRight},
+              &:not(:disabled)&:hover
+              ${ArrowRight} {
               border-left-color: ${darken(
                 0.1,
                 themeColor('secondary')({ theme }),
@@ -91,6 +96,7 @@ const getVariant = () => ({
         background-color: ${themeColor('tint', 'level4')};
         ${svgFill(themeColor('tint', 'level7'))};
 
+        &:focus,
         &:hover {
           background-color: ${darken(
             0.1,


### PR DESCRIPTION
As discussed with DST I’ve updated some Buttons focus state. The focus state on the `primary`, `secondary` and `tertiary` Buttons now have the same background-color as the hover. This makes the Button more striking for users that don't have a custom focus outline or focus color.

---

Old primary unfocussed:
<img src=https://user-images.githubusercontent.com/7781865/97464577-61d74a80-1941-11eb-87e1-670b12569159.png width=15% />

Old primary focussed:
<img src=https://user-images.githubusercontent.com/7781865/97464500-453b1280-1941-11eb-898b-451a6f4df634.png width=15% />

New primary focussed:
<img src=https://user-images.githubusercontent.com/7781865/97464399-276dad80-1941-11eb-9267-b7369621214d.png width=15% />

---

Old tertiary unfocussed:
<img src=https://user-images.githubusercontent.com/7781865/97464853-b7abf280-1941-11eb-8a34-b69dcb97960d.png width=15% />


Old tertiary focussed:
<img src=https://user-images.githubusercontent.com/7781865/97464870-be3a6a00-1941-11eb-9bd9-0ff416765380.png width=15% />


New tertiary focussed:
<img src=https://user-images.githubusercontent.com/7781865/97464898-c4c8e180-1941-11eb-81c8-3f59ffeb2024.png width=15% />
