### PR TITLE
Fixed the Modal component `zIndexOffset` prop warning 

### DIFF
--- a/packages/asc-ui/src/components/Focus/Focus.tsx
+++ b/packages/asc-ui/src/components/Focus/Focus.tsx
@@ -1,9 +1,12 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import React from 'react'
+import styled from 'styled-components'
 
 type Props = {
   onKeyDown?: React.EventHandler<React.KeyboardEvent>
 }
+
+const FocusStyle = styled.div``
 
 const Focus: React.FC<Props> = ({ children, onKeyDown, ...otherProps }) => {
   const myRef = React.createRef<HTMLDivElement>()
@@ -28,7 +31,7 @@ const Focus: React.FC<Props> = ({ children, onKeyDown, ...otherProps }) => {
   }, [myRef])
 
   return (
-    <div
+    <FocusStyle
       {...otherProps}
       role="presentation"
       ref={myRef}
@@ -36,7 +39,7 @@ const Focus: React.FC<Props> = ({ children, onKeyDown, ...otherProps }) => {
       tabIndex={0}
     >
       {children}
-    </div>
+    </FocusStyle>
   )
 }
 


### PR DESCRIPTION
When triggering the Modal, React ~~gives~~ gave a warning about a `zIndexOffset` prop that is not recognised.

See #1289