### PR TITLE
Change the html container for the logo (WCAG)

### DIFF
--- a/packages/asc-ui/src/components/Header/HeaderLogoTextStyle.ts
+++ b/packages/asc-ui/src/components/Header/HeaderLogoTextStyle.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-const HeaderLogoTextStyle = styled.h1`
+const HeaderLogoTextStyle = styled.div`
   margin: 0;
   font-weight: 700;
   display: flex;


### PR DESCRIPTION
This PR:
- changes the html element in the logo from `h1` to `div` for wcag compliance

Note: the changelog will be updated when consent is reached