### PR TITLE
Added `headerLogoTextAs` prop to `Header` component to overwrite the default `h1` tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## [UNRELEASED]
+
+- Added: `headerLogoTextAs` prop to `Header` component to overwrite the default `h1` tag
+
 ## [0.26.1]
 
 - Changed: Types for the `Alert` component (`AlertProps` and `AlertLevel`) are now exported from the package root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Prefix the change with one of these keywords:
 ## Unreleased
 
 - Added: `headerLogoTextAs` prop to `Header` component to overwrite the default `h1` tag
-- Fixed: The select component shows the default browser focus
+- Fixed: The `Select` component shows the default browser focus
 
 ## [0.26.1]
 

--- a/packages/asc-ui/src/components/Button/Button.tsx
+++ b/packages/asc-ui/src/components/Button/Button.tsx
@@ -1,4 +1,10 @@
-import React from 'react'
+import React, {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ElementType,
+  forwardRef,
+  ReactNode,
+} from 'react'
 import Icon, { defaultProps as iconDefaultProps } from '../Icon/Icon'
 import ButtonStyle, {
   ArrowRight,
@@ -9,23 +15,20 @@ import ButtonStyle, {
 } from './ButtonStyle'
 
 export type ButtonProps = {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>
-  forwardedAs?: keyof JSX.IntrinsicElements | React.ComponentType<any>
-  iconLeft?: React.ReactNode
-  iconRight?: React.ReactNode
-  icon?: React.ReactNode
+  as?: ElementType
+  forwardedAs?: ElementType
+  iconLeft?: ReactNode
+  iconRight?: ReactNode
+  icon?: ReactNode
   iconSize?: number
   taskflow?: boolean
 } & ButtonStyleProps &
-  React.AnchorHTMLAttributes<HTMLAnchorElement> &
-  React.ButtonHTMLAttributes<HTMLButtonElement>
+  AnchorHTMLAttributes<HTMLAnchorElement> &
+  ButtonHTMLAttributes<HTMLButtonElement>
 
 export { ButtonVariant }
 
-const Button = React.forwardRef<
-  HTMLButtonElement | HTMLAnchorElement,
-  ButtonProps
->(
+const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
   (
     { children, iconLeft, iconRight, icon, iconSize, taskflow, ...otherProps },
     ref,

--- a/packages/asc-ui/src/components/Header/Header.tsx
+++ b/packages/asc-ui/src/components/Header/Header.tsx
@@ -16,6 +16,7 @@ type Props = {
   navigation?: React.ReactNode
   links?: React.ReactNode
   logo?: React.FC<LogoProps>
+  headerLogoTextAs?: React.ComponentType<any>
 } & HeaderWrapperProps &
   HeaderStyleProps &
   CustomCssPropsType &
@@ -30,11 +31,15 @@ const Header: React.FC<Props> = ({
   navigation,
   links,
   logo,
+  headerLogoTextAs,
   ...otherProps
 }) => (
   <HeaderWrapperStyle {...{ css, tall }} id="header">
     <HeaderStyle {...{ fullWidth, ...otherProps }}>
-      <HeaderLogoText {...{ tall, title, homeLink, logo }} />
+      <HeaderLogoText
+        as={headerLogoTextAs}
+        {...{ tall, title, homeLink, logo }}
+      />
       <HeaderNavigation>{navigation}</HeaderNavigation>
       <HeaderLinks>{links}</HeaderLinks>
     </HeaderStyle>

--- a/packages/asc-ui/src/components/Header/Header.tsx
+++ b/packages/asc-ui/src/components/Header/Header.tsx
@@ -1,28 +1,33 @@
-import React from 'react'
+import React, {
+  ElementType,
+  FunctionComponent,
+  HTMLAttributes,
+  ReactNode,
+} from 'react'
+import { CustomCssPropsType } from '../../utils'
+import AmsterdamLogo from '../AmsterdamLogo'
+import HeaderLinks from './HeaderLinks'
+import HeaderLogoText, { LogoProps } from './HeaderLogoText'
+import HeaderNavigation from './HeaderNavigation'
 import HeaderStyle, { Props as HeaderStyleProps } from './HeaderStyle'
 import HeaderWrapperStyle, {
   Props as HeaderWrapperProps,
 } from './HeaderWrapperStyle'
-import HeaderLogoText, { LogoProps } from './HeaderLogoText'
-import HeaderNavigation from './HeaderNavigation'
-import HeaderLinks from './HeaderLinks'
-import { CustomCssPropsType } from '../../utils'
-import AmsterdamLogo from '../AmsterdamLogo'
 
-type Props = {
+type HeaderProps = {
   tall?: boolean
   homeLink: string
   title?: string
-  navigation?: React.ReactNode
-  links?: React.ReactNode
-  logo?: React.FC<LogoProps>
-  headerLogoTextAs?: React.ComponentType<any>
+  navigation?: ReactNode
+  links?: ReactNode
+  logo?: FunctionComponent<LogoProps>
+  headerLogoTextAs?: ElementType
 } & HeaderWrapperProps &
   HeaderStyleProps &
   CustomCssPropsType &
-  React.HTMLAttributes<HTMLDivElement>
+  HTMLAttributes<HTMLDivElement>
 
-const Header: React.FC<Props> = ({
+const Header: FunctionComponent<HeaderProps> = ({
   css,
   title,
   homeLink,

--- a/packages/asc-ui/src/components/Header/HeaderContent.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderContent.tsx
@@ -1,12 +1,13 @@
-import React, { ReactNode } from 'react'
+import React, { FunctionComponent, HTMLAttributes, ReactNode } from 'react'
 import HeaderContentStyle from './HeaderContentStyle'
 
 type Props = {
   children: ReactNode
-} & React.HTMLAttributes<HTMLDivElement>
+} & HTMLAttributes<HTMLDivElement>
 
-const HeaderContent: React.FC<Props> = ({ children, ...otherProps }) => (
-  <HeaderContentStyle {...otherProps}>{children}</HeaderContentStyle>
-)
+const HeaderContent: FunctionComponent<Props> = ({
+  children,
+  ...otherProps
+}) => <HeaderContentStyle {...otherProps}>{children}</HeaderContentStyle>
 
 export default HeaderContent

--- a/packages/asc-ui/src/components/Header/HeaderLinks.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderLinks.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { FunctionComponent, HTMLAttributes } from 'react'
 import HeaderLinksStyle from './HeaderLinksStyle'
 
-const HeaderLinks: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+const HeaderLinks: FunctionComponent<HTMLAttributes<HTMLDivElement>> = ({
   children,
   ...otherProps
 }) => <HeaderLinksStyle {...otherProps}>{children}</HeaderLinksStyle>

--- a/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
@@ -1,6 +1,6 @@
 import React, {
   AnchorHTMLAttributes,
-  ComponentType,
+  ElementType,
   FunctionComponent,
   HTMLAttributes,
 } from 'react'
@@ -14,7 +14,7 @@ export interface LogoProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 }
 
 interface HeaderLogoTextProps extends HTMLAttributes<HTMLHeadingElement> {
-  as?: string | ComponentType
+  as?: string | ElementType
   homeLink: string
   tall?: boolean
   logo?: FunctionComponent<LogoProps>

--- a/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { StyledProps } from 'styled-components'
 import HeaderLogoTextStyle from './HeaderLogoTextStyle'
 import HeaderTitle from './HeaderTitle'
 
@@ -15,7 +16,7 @@ interface HeaderLogoTextProps extends React.HTMLAttributes<HTMLHeadingElement> {
   logo?: React.FC<LogoProps>
 }
 
-const HeaderLogoText: React.FC<HeaderLogoTextProps> = ({
+const HeaderLogoText: React.FC<HeaderLogoTextProps & StyledProps<any>> = ({
   title,
   homeLink,
   tall,

--- a/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
@@ -1,5 +1,6 @@
 import React, {
   AnchorHTMLAttributes,
+  ComponentType,
   FunctionComponent,
   HTMLAttributes,
 } from 'react'
@@ -13,7 +14,7 @@ export interface LogoProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 }
 
 interface HeaderLogoTextProps extends HTMLAttributes<HTMLHeadingElement> {
-  as?: string | React.ComponentType
+  as?: string | ComponentType
   homeLink: string
   tall?: boolean
   logo?: FunctionComponent<LogoProps>

--- a/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
@@ -3,7 +3,6 @@ import React, {
   FunctionComponent,
   HTMLAttributes,
 } from 'react'
-import { StyledProps } from 'styled-components'
 import HeaderLogoTextStyle from './HeaderLogoTextStyle'
 import HeaderTitle from './HeaderTitle'
 
@@ -14,15 +13,21 @@ export interface LogoProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 }
 
 interface HeaderLogoTextProps extends HTMLAttributes<HTMLHeadingElement> {
+  as?: string | React.ComponentType
   homeLink: string
   tall?: boolean
   logo?: FunctionComponent<LogoProps>
 }
 
-const HeaderLogoText: FunctionComponent<
-  HeaderLogoTextProps & StyledProps<any>
-> = ({ title, homeLink, tall, logo: LogoIcon, ...otherProps }) => (
-  <HeaderLogoTextStyle {...otherProps}>
+const HeaderLogoText: FunctionComponent<HeaderLogoTextProps> = ({
+  as,
+  title,
+  homeLink,
+  tall,
+  logo: LogoIcon,
+  ...otherProps
+}) => (
+  <HeaderLogoTextStyle as={as} {...otherProps}>
     {LogoIcon && <LogoIcon href={homeLink} title={title} tall={tall} />}
     {title && <HeaderTitle href={homeLink}>{title}</HeaderTitle>}
   </HeaderLogoTextStyle>

--- a/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
@@ -1,28 +1,27 @@
-import React from 'react'
+import React, {
+  AnchorHTMLAttributes,
+  FunctionComponent,
+  HTMLAttributes,
+} from 'react'
 import { StyledProps } from 'styled-components'
 import HeaderLogoTextStyle from './HeaderLogoTextStyle'
 import HeaderTitle from './HeaderTitle'
 
-export interface LogoProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface LogoProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string
   tall?: boolean
   title?: string
 }
 
-interface HeaderLogoTextProps extends React.HTMLAttributes<HTMLHeadingElement> {
+interface HeaderLogoTextProps extends HTMLAttributes<HTMLHeadingElement> {
   homeLink: string
   tall?: boolean
-  logo?: React.FC<LogoProps>
+  logo?: FunctionComponent<LogoProps>
 }
 
-const HeaderLogoText: React.FC<HeaderLogoTextProps & StyledProps<any>> = ({
-  title,
-  homeLink,
-  tall,
-  logo: LogoIcon,
-  ...otherProps
-}) => (
+const HeaderLogoText: FunctionComponent<
+  HeaderLogoTextProps & StyledProps<any>
+> = ({ title, homeLink, tall, logo: LogoIcon, ...otherProps }) => (
   <HeaderLogoTextStyle {...otherProps}>
     {LogoIcon && <LogoIcon href={homeLink} title={title} tall={tall} />}
     {title && <HeaderTitle href={homeLink}>{title}</HeaderTitle>}

--- a/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderLogoText.tsx
@@ -14,7 +14,7 @@ export interface LogoProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 }
 
 interface HeaderLogoTextProps extends HTMLAttributes<HTMLHeadingElement> {
-  as?: string | ElementType
+  as?: ElementType
   homeLink: string
   tall?: boolean
   logo?: FunctionComponent<LogoProps>

--- a/packages/asc-ui/src/components/Header/HeaderTitle.tsx
+++ b/packages/asc-ui/src/components/Header/HeaderTitle.tsx
@@ -1,10 +1,9 @@
-import React from 'react'
+import React, { AnchorHTMLAttributes, FunctionComponent } from 'react'
 import HeaderTitleStyle from './HeaderTitleStyle'
 
-const HeaderTitle: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
-  children,
-  ...otherProps
-}) => {
+const HeaderTitle: FunctionComponent<
+  AnchorHTMLAttributes<HTMLAnchorElement>
+> = ({ children, ...otherProps }) => {
   return <HeaderTitleStyle {...otherProps}>{children}</HeaderTitleStyle>
 }
 

--- a/packages/asc-ui/src/components/Toggle/Toggle.tsx
+++ b/packages/asc-ui/src/components/Toggle/Toggle.tsx
@@ -1,4 +1,15 @@
-import React, { HTMLAttributes } from 'react'
+import React, {
+  ButtonHTMLAttributes,
+  ElementType,
+  FunctionComponent,
+  KeyboardEvent,
+  HTMLAttributes,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import ToggleStyle, { Props as ToggleStyleProps } from './ToggleStyle'
 import ownerDocument from '../../utils/ownerDocument'
 import usePassPropsToChildren from '../../utils/hooks/usePassPropsToChildren'
@@ -9,25 +20,25 @@ import ToggleButton, {
 import BackDrop, { Props as BackDropProps } from '../BackDrop/BackDrop'
 
 export type ToggleHandlerProps = {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>
+  as?: ElementType
 } & ToggleButtonProps &
-  React.HTMLAttributes<HTMLElement>
+  HTMLAttributes<HTMLElement>
 
 export type Props = {
   render?: boolean
   ariaLabel?: string
   onOpen?: (open: boolean) => void
-  ToggleHandler?: React.FC<
-    ToggleButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>
+  ToggleHandler?: FunctionComponent<
+    ToggleButtonProps & ButtonHTMLAttributes<HTMLButtonElement>
   >
   rotateOnOpen?: number
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>
+  as?: ElementType
 } & ToggleStyleProps &
   ToggleHandlerProps &
   BackDropProps
 
 // Todo: refactor this to Collapse component https://github.com/Amsterdam/amsterdam-styled-components/issues/379
-const Toggle: React.FC<Props & HTMLAttributes<HTMLDivElement>> = ({
+const Toggle: FunctionComponent<Props & HTMLAttributes<HTMLDivElement>> = ({
   children: childrenProps,
   onClick,
   open: openProp,
@@ -45,9 +56,9 @@ const Toggle: React.FC<Props & HTMLAttributes<HTMLDivElement>> = ({
   ariaLabel,
   ...otherProps
 }) => {
-  const [open, setOpen] = React.useState(false)
+  const [open, setOpen] = useState(false)
 
-  const handleOnOpen = React.useCallback(
+  const handleOnOpen = useCallback(
     (openParam: boolean) => {
       setOpen(openParam)
 
@@ -63,7 +74,7 @@ const Toggle: React.FC<Props & HTMLAttributes<HTMLDivElement>> = ({
   const { onKeyDown: onKeyDownHook } = useActionOnEscape(() =>
     handleOnOpen(false),
   )
-  const ref = React.useRef<HTMLDivElement>(null!)
+  const ref = useRef<HTMLDivElement>(null!)
 
   const handleOnBlur = () => {
     setTimeout(() => {
@@ -77,14 +88,14 @@ const Toggle: React.FC<Props & HTMLAttributes<HTMLDivElement>> = ({
     })
   }
 
-  const handleOnKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+  const handleOnKeyDown = (e: KeyboardEvent<HTMLElement>) => {
     onKeyDownHook(e)
     if (onKeyDown) {
       onKeyDown(e)
     }
   }
 
-  const handleOnClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+  const handleOnClick = (e: MouseEvent<HTMLElement>) => {
     handleOnOpen(!open)
 
     if (onClick) {
@@ -97,7 +108,7 @@ const Toggle: React.FC<Props & HTMLAttributes<HTMLDivElement>> = ({
   })
 
   // Useful if parent needs to take over control the isOpen state
-  React.useEffect(() => {
+  useEffect(() => {
     if (typeof openProp !== 'undefined') {
       handleOnOpen(openProp)
     }

--- a/stories/src/ui/Header.stories.mdx
+++ b/stories/src/ui/Header.stories.mdx
@@ -20,12 +20,7 @@ Given the `tall={false}` prop, this will make sure the header is not showing its
 <Preview>
   <Story name="Short only">
     <React.Fragment>
-      <Header
-        headerLogoTextAs="div" // Now the HeaderLogoText component will be a `div`
-        tall={false}
-        title="Some title"
-        fullWidth={false}
-      />
+      <Header tall={false} title="Some title" fullWidth={false} />
     </React.Fragment>
   </Story>
 </Preview>
@@ -48,6 +43,18 @@ To see the tall version, please make sure your viewport is bigger than laptopM (
   <Story name="Tall">
     <React.Fragment>
       <Header tall title="Some title" fullWidth={false} />
+    </React.Fragment>
+  </Story>
+</Preview>
+
+## Overwrite the default h1 tag
+
+Use `headerLogoTextAs` to overwrite the default `h1` tag on the logo. Useful for SEO purposes.
+
+<Preview>
+  <Story name="Overwrite the default h1 tag">
+    <React.Fragment>
+      <Header headerLogoTextAs="div" tall={false} title="Some title" />
     </React.Fragment>
   </Story>
 </Preview>

--- a/stories/src/ui/Header.stories.mdx
+++ b/stories/src/ui/Header.stories.mdx
@@ -20,7 +20,12 @@ Given the `tall={false}` prop, this will make sure the header is not showing its
 <Preview>
   <Story name="Short only">
     <React.Fragment>
-      <Header tall={false} title="Some title" fullWidth={false} />
+      <Header
+        headerLogoTextAs="div" // Now the HeaderLogoText component will be a `div`
+        tall={false}
+        title="Some title"
+        fullWidth={false}
+      />
     </React.Fragment>
   </Story>
 </Preview>


### PR DESCRIPTION
Demo for @aditudorache 

#### with `headerLogoTextAs="div"`:
![image](https://user-images.githubusercontent.com/7781865/100254889-1feef380-2f43-11eb-99dd-043582caae2c.png)

#### without `headerLogoTextAs` prop:
![image](https://user-images.githubusercontent.com/7781865/100255012-490f8400-2f43-11eb-90a6-f9799cc73e7b.png)
