### PR TITLE
Taskflow button has better focus state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Prefix the change with one of these keywords:
 
 ## [new version]
 
+- Fixed: Taskflow button has better focus state
 - Changed: Line-height of breadcrumbs component according to spec.
 - Changed: **BREAKING** hooks object is not exported anymore. You can import hooks now directly, for example import { useFocus } from '@amsterdam/asc-ui' [#1120]
 - Removed: **BREAKING** the variant prop in Checkbox component, [#1539](https://github.com/Amsterdam/amsterdam-styled-components/pull/1539)

--- a/packages/asc-ui/src/components/Button/ButtonStyle.ts
+++ b/packages/asc-ui/src/components/Button/ButtonStyle.ts
@@ -22,9 +22,9 @@ export const getButtonHeight = (theme: Theme.ThemeInterface) =>
   themeSpacing(11)({ theme })
 
 export const ArrowRight = styled.div`
-  position: absolute;
+  position: relative;
   top: 0;
-  left: 100%;
+  right: -15px;
   width: 0;
   height: 0;
   border: 22px solid rgba(255, 255, 255, 0);
@@ -244,6 +244,7 @@ const ButtonStyle = styled.button<ButtonStyleProps>`
     taskflow &&
     css`
       position: relative;
+      padding-right: 0;
       z-index: 0;
       && {
         margin-right: 25px;

--- a/stories/src/ui/Button.stories.mdx
+++ b/stories/src/ui/Button.stories.mdx
@@ -24,8 +24,10 @@ import {
 
 export const ButtonBar = styled.div`
   display: flex;
+  flex-wrap: wrap;
   & > * {
     margin-right: 5px;
+    margin-bottom: 5px;
   }
 `
 


### PR DESCRIPTION
## The taskflow state button has a small bug in the focus state.

Default:
![image](https://user-images.githubusercontent.com/7781865/111183547-4c8d5080-85b0-11eb-8e2b-d2139e54546c.png)

Focus, with bug ([see storybook](https://amsterdam.github.io/amsterdam-styled-components/?path=/docs/ui-form-button--default-primary-variant)):
![image](https://user-images.githubusercontent.com/7781865/111183562-51ea9b00-85b0-11eb-8695-5f3d3271aae8.png)

Focus, without bug (compare with Netlify):
![image](https://user-images.githubusercontent.com/7781865/111183701-7b0b2b80-85b0-11eb-89ba-946a4481fa0c.png)

