### PR TITLE
Fixed clear button alignment for (search) inputs

### DIFF
--- a/packages/asc-ui/src/components/TextField/TextFieldStyle.ts
+++ b/packages/asc-ui/src/components/TextField/TextFieldStyle.ts
@@ -6,8 +6,9 @@ const TextFieldStyle = styled.div`
 
   & > ${ButtonStyle} {
     position: absolute;
-    top: 5px;
-    right: 5px;
+    top: 3px;
+    right: 3px;
+    height: calc(100% - 6px);
   }
 `
 


### PR DESCRIPTION
A simple fix for the alignment of the clear button in search inputs since it overlapped with the focus outline.

Before:
<img width="434" alt="Screenshot 2021-05-12 at 23 43 33" src="https://user-images.githubusercontent.com/13944585/118048777-0c163d00-b37d-11eb-81a8-c6ec01ba4070.png">

After:
<img width="434" alt="Screenshot 2021-05-12 at 23 42 02" src="https://user-images.githubusercontent.com/13944585/118048958-5dbec780-b37d-11eb-8399-ed1cf1717d5c.png">



