### PR TITLE
Styling Breadcrumbs

### DIFF
--- a/packages/asc-ui/src/components/Breadcrumbs/BreadcrumbsStyle.tsx
+++ b/packages/asc-ui/src/components/Breadcrumbs/BreadcrumbsStyle.tsx
@@ -15,7 +15,8 @@ export default styled.ol`
     align-items: center;
     color: ${themeColor('secondary', 'main')};
 
-    a, span {
+    a,
+    span {
       font-size: 14px;
       line-height: 22px;
       color: ${themeColor('tint', 'level5')};

--- a/packages/asc-ui/src/components/Breadcrumbs/BreadcrumbsStyle.tsx
+++ b/packages/asc-ui/src/components/Breadcrumbs/BreadcrumbsStyle.tsx
@@ -15,14 +15,16 @@ export default styled.ol`
     align-items: center;
     color: ${themeColor('secondary', 'main')};
 
-    a {
+    a, span {
       font-size: 14px;
       line-height: 22px;
       color: ${themeColor('tint', 'level5')};
       text-decoration: none;
       text-decoration-color: ${themeColor('tint', 'level5')};
       margin: ${themeSpacing(0, 2, 0, 0)};
+    }
 
+    a {
       &:hover {
         color: ${themeColor('secondary', 'main')};
         text-decoration: underline;

--- a/packages/asc-ui/src/components/Breadcrumbs/BreadcrumbsStyle.tsx
+++ b/packages/asc-ui/src/components/Breadcrumbs/BreadcrumbsStyle.tsx
@@ -8,6 +8,7 @@ export default styled.ol`
   flex-wrap: wrap;
   margin: 0;
   list-style: none;
+  padding-inline-start: 0;
 
   li {
     display: flex;

--- a/stories/src/ui/Breadcrumbs.stories.mdx
+++ b/stories/src/ui/Breadcrumbs.stories.mdx
@@ -23,8 +23,9 @@ export const Decorator = styled.div``
     <Breadcrumbs>
       <a href="/">Home</a>
       <a href="/innovatie">Innovatie</a>
-      <a href="/innovatie/bouwprojecten">Bouw- en verkkeersprojecten</a>
+      <a href="/innovatie/bouwprojecten">Bouw- en verkeersprojecten</a>
       <a href="/innovatie/bouwprojecten/contact">Contact</a>
+      <span>Ankerloos</span>
     </Breadcrumbs>
   </Story>
 </Preview>


### PR DESCRIPTION
- Remove padding-inline-start spacing from ordered list
- Also style span children. This makes it possible to also add items that are not anchor links (like the current page).

## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [x] You've added or updated the README.mdx of the story of the component
- [x] You have been following the guidelines, written in the [README](../blob/main/docs/CONTRIBUTING.md#user-content-conventions-and-rules) file
- [x] Your code has the necessary tests written
- [x] You've exported the component in [index.ts](./packages/asc-ui/src/index.ts)
- [ ] You have updated the [CHANGELOG.md unreleased sections](../blob/main/CHANGELOG.md#muser-content-unreleased)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
