### PR TITLE
Change radio/checkbox components wrapper tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Prefix the change with one of these keywords:
 - Removed: Console warning in `ContextMenu` for not passing the right children
 - Removed: Support for React 16
 - Removed: `ViewerContainer` component
+- Changed: `Radio` and `Checkbox` component HTML div tag to span
 
 - Added: Datepicker component
 

--- a/packages/asc-ui/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/asc-ui/src/components/Checkbox/Checkbox.test.tsx
@@ -1,5 +1,5 @@
 import { createRef } from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import Checkbox from './Checkbox'
 import { ascDefaultTheme, ThemeProvider } from '../../theme'
 import { themeColor } from '../../utils'
@@ -7,14 +7,14 @@ import { themeColor } from '../../utils'
 describe('Checkbox', () => {
   it('should toggle checked / not checked', () => {
     const onChangeMock = jest.fn()
-    const { container } = render(
+    render(
       <ThemeProvider>
         <Checkbox onChange={onChangeMock} />
       </ThemeProvider>,
     )
 
-    const checkBox = container.querySelector('input')
-    const icon = container.querySelector('span')
+    const checkBox = screen.getByRole('checkbox')
+    const icon = screen.getByTestId('checkboxIcon')
 
     expect(icon).toHaveStyleRule(
       'background-color',

--- a/packages/asc-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/asc-ui/src/components/Checkbox/Checkbox.tsx
@@ -62,6 +62,7 @@ const Checkbox = forwardRef<
       >
         <CheckboxIconStyle
           {...{ disabled, checked, error, indeterminate }}
+          data-testid="checkboxIcon"
           size={15}
         >
           {!checked && indeterminate && <Indeterminate />}

--- a/packages/asc-ui/src/components/Checkbox/CheckboxStyle.ts
+++ b/packages/asc-ui/src/components/Checkbox/CheckboxStyle.ts
@@ -44,7 +44,7 @@ const CheckboxIconStyle = styled(IconStyle)<Props>`
     `};
 `
 
-const CheckboxWrapperStyle = styled.div<Props>`
+const CheckboxWrapperStyle = styled.span<Props>`
   position: relative;
   display: inline-flex;
   user-select: none;

--- a/packages/asc-ui/src/components/Radio/RadioStyle.ts
+++ b/packages/asc-ui/src/components/Radio/RadioStyle.ts
@@ -72,7 +72,7 @@ const RadioCircleStyle = styled.span<StyleOnlyProps>`
     `}
 `
 
-const RadioWrapperStyle = styled.div<StyleOnlyProps & { focus: boolean }>`
+const RadioWrapperStyle = styled.span<StyleOnlyProps & { focus: boolean }>`
   position: relative;
   display: inline-flex;
   user-select: none;


### PR DESCRIPTION
When using a `<Checkbox />` or `<Radio />` component, we have to wrap the component with a label to make sure that both the label and the input are clickable.

``` 
// Radio.stories.mdx
<RadioGroup name="group">
  <Label htmlFor="radio-1" label="Default">
    <Radio id="radio-1" />
  </Label>
  <Label htmlFor="radio-2" label="Checked">
    <Radio id="radio-2" checked />
  </Label>
</RadioGroup>
```

However, this means that labels contain a `div` tag (In `<Radio />`), which is invalid HTML: `div` is not part of the [content model](https://html.spec.whatwg.org/multipage/forms.html#the-label-element) of a label. This PR changes it to a `span`