### PR TITLE
Fixed: default 100% width for `Table` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## [0.32.1]
+
+- Fixed: default 100% width for `Table` component
+
 ## [0.32.0]
 
 - Added: experimental `Table` component

--- a/packages/asc-ui/src/components/Table/Table.tsx
+++ b/packages/asc-ui/src/components/Table/Table.tsx
@@ -2,7 +2,8 @@ import styled from 'styled-components'
 import { themeSpacing } from '../../utils'
 
 const Table = styled.table`
-  display: inline-block;
+  display: table;
+  width: 100%;
   border-spacing: 0;
   overflow: auto;
   padding-right: ${themeSpacing(3)};

--- a/stories/src/ui/Table.stories.mdx
+++ b/stories/src/ui/Table.stories.mdx
@@ -11,7 +11,21 @@ import {
 } from '@amsterdam/asc-ui'
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
 
-<Meta title="UI/Table" component={Table} />
+<Meta
+  title="UI/Table"
+  component={Table}
+  decorators={[
+    (Item) => (
+      <div
+        style={{
+          maxWidth: '1000px',
+        }}
+      >
+        <Item />
+      </div>
+    ),
+  ]}
+/>
 
 # Table
 


### PR DESCRIPTION
## Amsterdam styled components pull request

Before opening a pull request, please ensure:

- [ ] You've added or updated the README.mdx of the story of the component
- [ ] You have been following the guidelines, written in the [README](../blob/main/docs/CONTRIBUTING.md#user-content-conventions-and-rules) file
- [ ] Your code has the necessary tests written
- [ ] You've exported the component in [index.ts](./packages/asc-ui/src/index.ts)
- [ ] You have updated the [CHANGELOG.md unreleased sections](../blob/main/CHANGELOG.md#muser-content-unreleased)

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
